### PR TITLE
Presentation ID Fix - Added support for assetname overrides based on franchise fingerprint

### DIFF
--- a/presentationIdFix/buildExe.bat
+++ b/presentationIdFix/buildExe.bat
@@ -1,1 +1,1 @@
-nexe --build -i presentationIdFix.js -t x64-14.15.3 -r "../node_modules/madden-franchise/data/schemas" -r "../lookupFunctions/FranchiseUtils.js" -r "../lookupFunctions/FranchiseTableId.js" -o "presentationIdFix.exe" --verbose
+nexe --build -i presentationIdFix.js -t x64-14.15.3 -r "../node_modules/madden-franchise/data/schemas" -r "lookupFiles/*.json" -r "../lookupFunctions/FranchiseUtils.js" -r "../lookupFunctions/FranchiseTableId.js" -o "presentationIdFix.exe" --verbose

--- a/presentationIdFix/lookupFiles/WiiMaster2015.json
+++ b/presentationIdFix/lookupFiles/WiiMaster2015.json
@@ -1,0 +1,4 @@
+{
+	"M24_agent": "LuckAndrew_11209",
+	"M24_Coordinator": "PalmerCarson_512"
+}

--- a/presentationIdFix/lookupFiles/WiiMaster2017.json
+++ b/presentationIdFix/lookupFiles/WiiMaster2017.json
@@ -1,0 +1,4 @@
+{
+	"PolamaluTroy_16548": "LuckAndrew_11209",
+	"StrahanMichael_999": ""	
+}


### PR DESCRIPTION
Updated the presentation ID fix tool to have support for assetname override via JSON for files that are fingerprinted in a certain way. This will ensure presentation IDs are still set correctly for files with custom player cyberfaces.

Others can add their own files to the system by simply adding their fingerprint(s) to the valid fingerprint list in the JS file, and then creating a JSON of the same name in the lookup files folder (case sensitive). Two base JSONs for my mods are included as a sample.