### PR TITLE
Added FranchiseDebugModule to table ID list, presentation ID fix tool updates

### DIFF
--- a/lookupFunctions/FranchiseTableId.js
+++ b/lookupFunctions/FranchiseTableId.js
@@ -127,8 +127,10 @@ const tables = {
     talentFtcTable: 2347346465,
 
     //Training tables
-    drillCompletedTable: 1204263071
+    drillCompletedTable: 1204263071,
     
+    //Franchise Debug Table, primarily used for franchise file fingerprinting
+    franchiseDebugModuleTable: 4212179270
 
 
 

--- a/presentationIdFix/presentationIdFix.js
+++ b/presentationIdFix/presentationIdFix.js
@@ -103,7 +103,16 @@ franchise.on('ready', async function () {
         }
 		
 		// Get player's assetname value
-        var playerAssetName = playerTable.records[i]['PLYR_ASSETNAME'];
+        let playerAssetName = playerTable.records[i]['PLYR_ASSETNAME'];
+
+		// Clean up assetname by removing spaces
+		playerAssetName = playerAssetName.trim();
+
+		// Account for selective strandhair by removing "_nostrand" from the assetname if it exists
+		if(playerAssetName.includes('_nostrand'))
+		{
+			playerAssetName = playerAssetName.replace('_nostrand', '');
+		}
 		
 		// If this is a file with custom cyberfaces and this assetname is one that has an override, use the override assetname instead
 		if(customMeshFile && overrideAssetNames.hasOwnProperty(playerAssetName))
@@ -117,8 +126,16 @@ franchise.on('ready', async function () {
 
         if (underscoreIndex !== -1) 
 		{
-			// Extract the numbers after the underscore and convert them to an integer
-			newPresentationId = parseInt(playerAssetName.substring(underscoreIndex + 1), 10);
+			try
+			{
+				// Extract the numbers after the underscore and convert them to an integer
+				newPresentationId = parseInt(playerAssetName.substring(underscoreIndex + 1), 10);
+			}
+			catch(e)
+			{
+				// If unable to parse, set the presentation ID to 0
+				newPresentationId = 0;
+			}
 		} 
 		else 
 		{

--- a/presentationIdFix/presentationIdFix.js
+++ b/presentationIdFix/presentationIdFix.js
@@ -60,7 +60,7 @@ franchise.on('ready', async function () {
 	if(gameYear === '24')
 	{
 		// Get the fingerprint from the file, if it's in the list, then set the bool to true and read the override file
-		fingerprintTable = franchise.getTableByUniqueId(4212179270);
+		fingerprintTable = franchise.getTableByUniqueId(tables.franchiseDebugModuleTable);
 		await fingerprintTable.readRecords();
 		fingerprint = fingerprintTable.records[0]['SideActivityToForce'];
 		if(customMeshFingerprints.includes(fingerprint))


### PR DESCRIPTION
Added the franchise debug module table to the table ID list (used mainly for franchise file fingerprinting) and updated the presentation ID fix tool accordingly.

Also snuck in some fixes for the presentation ID fix tool, including handling assetnames that have an underscore but don't have numbers (such as some actor slots) and accounting for assetnames with leading/trailing whitespace.