### PR TITLE
Schedule Extractor & Schedule Importer - Various fixes and additions

### DIFF
--- a/retroSchedules/schedules/2024.json
+++ b/retroSchedules/schedules/2024.json
@@ -1,0 +1,1745 @@
+{
+  "year": "2024",
+  "weeks": [
+    {
+      "type": "season",
+      "number": "1",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:20PM",
+          "homeTeam": "Kansas City Chiefs",
+          "awayTeam": "Baltimore Ravens"
+        },
+        {
+          "day": "Fri",
+          "time": "8:15PM",
+          "homeTeam": "Philadelphia Eagles",
+          "awayTeam": "Green Bay Packers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Atlanta Falcons",
+          "awayTeam": "Pittsburgh Steelers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Buffalo Bills",
+          "awayTeam": "Arizona Cardinals"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Chicago Bears",
+          "awayTeam": "Tennessee Titans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Cincinnati Bengals",
+          "awayTeam": "New England Patriots"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Indianapolis Colts",
+          "awayTeam": "Houston Texans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Miami Dolphins",
+          "awayTeam": "Jacksonville Jaguars"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New Orleans Saints",
+          "awayTeam": "Carolina Panthers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Giants",
+          "awayTeam": "Minnesota Vikings"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Los Angeles Chargers",
+          "awayTeam": "Las Vegas Raiders"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Seattle Seahawks",
+          "awayTeam": "Denver Broncos"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Cleveland Browns",
+          "awayTeam": "Dallas Cowboys"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Tampa Bay Buccaneers",
+          "awayTeam": "Washington Commanders"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Detroit Lions",
+          "awayTeam": "Los Angeles Rams"
+        },
+        {
+          "day": "Mon",
+          "time": "8:20PM",
+          "homeTeam": "San Francisco 49ers",
+          "awayTeam": "New York Jets"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "2",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "Miami Dolphins",
+          "awayTeam": "Buffalo Bills"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Dallas Cowboys",
+          "awayTeam": "New Orleans Saints"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Detroit Lions",
+          "awayTeam": "Tampa Bay Buccaneers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Green Bay Packers",
+          "awayTeam": "Indianapolis Colts"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tennessee Titans",
+          "awayTeam": "New York Jets"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Minnesota Vikings",
+          "awayTeam": "San Francisco 49ers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New England Patriots",
+          "awayTeam": "Seattle Seahawks"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Washington Commanders",
+          "awayTeam": "New York Giants"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Carolina Panthers",
+          "awayTeam": "Los Angeles Chargers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Jacksonville Jaguars",
+          "awayTeam": "Cleveland Browns"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Baltimore Ravens",
+          "awayTeam": "Las Vegas Raiders"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Arizona Cardinals",
+          "awayTeam": "Los Angeles Rams"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Denver Broncos",
+          "awayTeam": "Pittsburgh Steelers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Kansas City Chiefs",
+          "awayTeam": "Cincinnati Bengals"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Houston Texans",
+          "awayTeam": "Chicago Bears"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Philadelphia Eagles",
+          "awayTeam": "Atlanta Falcons"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "3",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "New York Jets",
+          "awayTeam": "New England Patriots"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Cleveland Browns",
+          "awayTeam": "New York Giants"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tennessee Titans",
+          "awayTeam": "Green Bay Packers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Indianapolis Colts",
+          "awayTeam": "Chicago Bears"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Minnesota Vikings",
+          "awayTeam": "Houston Texans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New Orleans Saints",
+          "awayTeam": "Philadelphia Eagles"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Pittsburgh Steelers",
+          "awayTeam": "Los Angeles Chargers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tampa Bay Buccaneers",
+          "awayTeam": "Denver Broncos"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Las Vegas Raiders",
+          "awayTeam": "Carolina Panthers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Seattle Seahawks",
+          "awayTeam": "Miami Dolphins"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Dallas Cowboys",
+          "awayTeam": "Baltimore Ravens"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Los Angeles Rams",
+          "awayTeam": "San Francisco 49ers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Arizona Cardinals",
+          "awayTeam": "Detroit Lions"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Atlanta Falcons",
+          "awayTeam": "Kansas City Chiefs"
+        },
+        {
+          "day": "Mon",
+          "time": "7:30PM",
+          "homeTeam": "Buffalo Bills",
+          "awayTeam": "Jacksonville Jaguars"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Cincinnati Bengals",
+          "awayTeam": "Washington Commanders"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "4",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "New York Giants",
+          "awayTeam": "Dallas Cowboys"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Atlanta Falcons",
+          "awayTeam": "New Orleans Saints"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Chicago Bears",
+          "awayTeam": "Los Angeles Rams"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Green Bay Packers",
+          "awayTeam": "Minnesota Vikings"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Indianapolis Colts",
+          "awayTeam": "Pittsburgh Steelers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Jets",
+          "awayTeam": "Denver Broncos"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tampa Bay Buccaneers",
+          "awayTeam": "Philadelphia Eagles"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Carolina Panthers",
+          "awayTeam": "Cincinnati Bengals"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Houston Texans",
+          "awayTeam": "Jacksonville Jaguars"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Arizona Cardinals",
+          "awayTeam": "Washington Commanders"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "San Francisco 49ers",
+          "awayTeam": "New England Patriots"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Las Vegas Raiders",
+          "awayTeam": "Cleveland Browns"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Los Angeles Chargers",
+          "awayTeam": "Kansas City Chiefs"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Baltimore Ravens",
+          "awayTeam": "Buffalo Bills"
+        },
+        {
+          "day": "Mon",
+          "time": "7:30PM",
+          "homeTeam": "Miami Dolphins",
+          "awayTeam": "Tennessee Titans"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Detroit Lions",
+          "awayTeam": "Seattle Seahawks"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "5",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "Atlanta Falcons",
+          "awayTeam": "Tampa Bay Buccaneers"
+        },
+        {
+          "day": "Sun",
+          "time": "9:30AM",
+          "homeTeam": "Minnesota Vikings",
+          "awayTeam": "New York Jets"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Chicago Bears",
+          "awayTeam": "Carolina Panthers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Cincinnati Bengals",
+          "awayTeam": "Baltimore Ravens"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New England Patriots",
+          "awayTeam": "Miami Dolphins"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Washington Commanders",
+          "awayTeam": "Cleveland Browns"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Jacksonville Jaguars",
+          "awayTeam": "Indianapolis Colts"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Houston Texans",
+          "awayTeam": "Buffalo Bills"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Denver Broncos",
+          "awayTeam": "Las Vegas Raiders"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "San Francisco 49ers",
+          "awayTeam": "Arizona Cardinals"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Los Angeles Rams",
+          "awayTeam": "Green Bay Packers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Seattle Seahawks",
+          "awayTeam": "New York Giants"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Pittsburgh Steelers",
+          "awayTeam": "Dallas Cowboys"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Kansas City Chiefs",
+          "awayTeam": "New Orleans Saints"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "6",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "Seattle Seahawks",
+          "awayTeam": "San Francisco 49ers"
+        },
+        {
+          "day": "Sun",
+          "time": "9:30AM",
+          "homeTeam": "Chicago Bears",
+          "awayTeam": "Jacksonville Jaguars"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Green Bay Packers",
+          "awayTeam": "Arizona Cardinals"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tennessee Titans",
+          "awayTeam": "Indianapolis Colts"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New England Patriots",
+          "awayTeam": "Houston Texans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New Orleans Saints",
+          "awayTeam": "Tampa Bay Buccaneers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Philadelphia Eagles",
+          "awayTeam": "Cleveland Browns"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Baltimore Ravens",
+          "awayTeam": "Washington Commanders"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Denver Broncos",
+          "awayTeam": "Los Angeles Chargers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Las Vegas Raiders",
+          "awayTeam": "Pittsburgh Steelers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Dallas Cowboys",
+          "awayTeam": "Detroit Lions"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Carolina Panthers",
+          "awayTeam": "Atlanta Falcons"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "New York Giants",
+          "awayTeam": "Cincinnati Bengals"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "New York Jets",
+          "awayTeam": "Buffalo Bills"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "7",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "New Orleans Saints",
+          "awayTeam": "Denver Broncos"
+        },
+        {
+          "day": "Sun",
+          "time": "9:30AM",
+          "homeTeam": "Jacksonville Jaguars",
+          "awayTeam": "New England Patriots"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Atlanta Falcons",
+          "awayTeam": "Seattle Seahawks"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Buffalo Bills",
+          "awayTeam": "Tennessee Titans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Cleveland Browns",
+          "awayTeam": "Cincinnati Bengals"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Green Bay Packers",
+          "awayTeam": "Houston Texans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Indianapolis Colts",
+          "awayTeam": "Miami Dolphins"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Minnesota Vikings",
+          "awayTeam": "Detroit Lions"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Giants",
+          "awayTeam": "Philadelphia Eagles"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Los Angeles Rams",
+          "awayTeam": "Las Vegas Raiders"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Washington Commanders",
+          "awayTeam": "Carolina Panthers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "San Francisco 49ers",
+          "awayTeam": "Kansas City Chiefs"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Pittsburgh Steelers",
+          "awayTeam": "New York Jets"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Tampa Bay Buccaneers",
+          "awayTeam": "Baltimore Ravens"
+        },
+        {
+          "day": "Mon",
+          "time": "9:00PM",
+          "homeTeam": "Arizona Cardinals",
+          "awayTeam": "Los Angeles Chargers"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "8",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "Los Angeles Rams",
+          "awayTeam": "Minnesota Vikings"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Cleveland Browns",
+          "awayTeam": "Baltimore Ravens"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Detroit Lions",
+          "awayTeam": "Tennessee Titans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Miami Dolphins",
+          "awayTeam": "Arizona Cardinals"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New England Patriots",
+          "awayTeam": "New York Jets"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tampa Bay Buccaneers",
+          "awayTeam": "Atlanta Falcons"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Washington Commanders",
+          "awayTeam": "Chicago Bears"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Jacksonville Jaguars",
+          "awayTeam": "Green Bay Packers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Houston Texans",
+          "awayTeam": "Indianapolis Colts"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Los Angeles Chargers",
+          "awayTeam": "New Orleans Saints"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Seattle Seahawks",
+          "awayTeam": "Buffalo Bills"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Cincinnati Bengals",
+          "awayTeam": "Philadelphia Eagles"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Denver Broncos",
+          "awayTeam": "Carolina Panthers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Las Vegas Raiders",
+          "awayTeam": "Kansas City Chiefs"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "San Francisco 49ers",
+          "awayTeam": "Dallas Cowboys"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Pittsburgh Steelers",
+          "awayTeam": "New York Giants"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "9",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "New York Jets",
+          "awayTeam": "Houston Texans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Atlanta Falcons",
+          "awayTeam": "Dallas Cowboys"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Buffalo Bills",
+          "awayTeam": "Miami Dolphins"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Cincinnati Bengals",
+          "awayTeam": "Las Vegas Raiders"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Cleveland Browns",
+          "awayTeam": "Los Angeles Chargers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tennessee Titans",
+          "awayTeam": "New England Patriots"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Minnesota Vikings",
+          "awayTeam": "Indianapolis Colts"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Giants",
+          "awayTeam": "Washington Commanders"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Carolina Panthers",
+          "awayTeam": "New Orleans Saints"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Baltimore Ravens",
+          "awayTeam": "Denver Broncos"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Arizona Cardinals",
+          "awayTeam": "Chicago Bears"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Green Bay Packers",
+          "awayTeam": "Detroit Lions"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Seattle Seahawks",
+          "awayTeam": "Los Angeles Rams"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Philadelphia Eagles",
+          "awayTeam": "Jacksonville Jaguars"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Kansas City Chiefs",
+          "awayTeam": "Tampa Bay Buccaneers"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "10",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "Baltimore Ravens",
+          "awayTeam": "Cincinnati Bengals"
+        },
+        {
+          "day": "Sun",
+          "time": "9:30AM",
+          "homeTeam": "Carolina Panthers",
+          "awayTeam": "New York Giants"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Chicago Bears",
+          "awayTeam": "New England Patriots"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Indianapolis Colts",
+          "awayTeam": "Buffalo Bills"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Kansas City Chiefs",
+          "awayTeam": "Denver Broncos"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New Orleans Saints",
+          "awayTeam": "Atlanta Falcons"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tampa Bay Buccaneers",
+          "awayTeam": "San Francisco 49ers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Washington Commanders",
+          "awayTeam": "Pittsburgh Steelers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Jacksonville Jaguars",
+          "awayTeam": "Minnesota Vikings"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Los Angeles Chargers",
+          "awayTeam": "Tennessee Titans"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Dallas Cowboys",
+          "awayTeam": "Philadelphia Eagles"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Arizona Cardinals",
+          "awayTeam": "New York Jets"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Houston Texans",
+          "awayTeam": "Detroit Lions"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Los Angeles Rams",
+          "awayTeam": "Miami Dolphins"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "11",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "Philadelphia Eagles",
+          "awayTeam": "Washington Commanders"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Chicago Bears",
+          "awayTeam": "Green Bay Packers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Detroit Lions",
+          "awayTeam": "Jacksonville Jaguars"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tennessee Titans",
+          "awayTeam": "Minnesota Vikings"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Miami Dolphins",
+          "awayTeam": "Las Vegas Raiders"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New England Patriots",
+          "awayTeam": "Los Angeles Rams"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New Orleans Saints",
+          "awayTeam": "Cleveland Browns"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Pittsburgh Steelers",
+          "awayTeam": "Baltimore Ravens"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Denver Broncos",
+          "awayTeam": "Atlanta Falcons"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "San Francisco 49ers",
+          "awayTeam": "Seattle Seahawks"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Buffalo Bills",
+          "awayTeam": "Kansas City Chiefs"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Los Angeles Chargers",
+          "awayTeam": "Cincinnati Bengals"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "New York Jets",
+          "awayTeam": "Indianapolis Colts"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Dallas Cowboys",
+          "awayTeam": "Houston Texans"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "12",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "Cleveland Browns",
+          "awayTeam": "Pittsburgh Steelers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Chicago Bears",
+          "awayTeam": "Minnesota Vikings"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Indianapolis Colts",
+          "awayTeam": "Detroit Lions"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Miami Dolphins",
+          "awayTeam": "New England Patriots"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Giants",
+          "awayTeam": "Tampa Bay Buccaneers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Washington Commanders",
+          "awayTeam": "Dallas Cowboys"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Carolina Panthers",
+          "awayTeam": "Kansas City Chiefs"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Houston Texans",
+          "awayTeam": "Tennessee Titans"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Las Vegas Raiders",
+          "awayTeam": "Denver Broncos"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Green Bay Packers",
+          "awayTeam": "San Francisco 49ers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Seattle Seahawks",
+          "awayTeam": "Arizona Cardinals"
+        },
+        {
+          "day": "Sun",
+          "time": "8:15PM",
+          "homeTeam": "Los Angeles Chargers",
+          "awayTeam": "Baltimore Ravens"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Los Angeles Rams",
+          "awayTeam": "Philadelphia Eagles"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "13",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "4:30PM",
+          "homeTeam": "Dallas Cowboys",
+          "awayTeam": "New York Giants"
+        },
+        {
+          "day": "Thu",
+          "time": "8:20PM",
+          "homeTeam": "Green Bay Packers",
+          "awayTeam": "Miami Dolphins"
+        },
+        {
+          "day": "Thu",
+          "time": "12:30PM",
+          "homeTeam": "Detroit Lions",
+          "awayTeam": "Chicago Bears"
+        },
+        {
+          "day": "Fri",
+          "time": "3:00PM",
+          "homeTeam": "Kansas City Chiefs",
+          "awayTeam": "Las Vegas Raiders"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Atlanta Falcons",
+          "awayTeam": "Los Angeles Chargers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Cincinnati Bengals",
+          "awayTeam": "Pittsburgh Steelers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Minnesota Vikings",
+          "awayTeam": "Arizona Cardinals"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New England Patriots",
+          "awayTeam": "Indianapolis Colts"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Jets",
+          "awayTeam": "Seattle Seahawks"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Washington Commanders",
+          "awayTeam": "Tennessee Titans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Jacksonville Jaguars",
+          "awayTeam": "Houston Texans"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "New Orleans Saints",
+          "awayTeam": "Los Angeles Rams"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Carolina Panthers",
+          "awayTeam": "Tampa Bay Buccaneers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Baltimore Ravens",
+          "awayTeam": "Philadelphia Eagles"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Buffalo Bills",
+          "awayTeam": "San Francisco 49ers"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Denver Broncos",
+          "awayTeam": "Cleveland Browns"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "14",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "Detroit Lions",
+          "awayTeam": "Green Bay Packers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tennessee Titans",
+          "awayTeam": "Jacksonville Jaguars"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Miami Dolphins",
+          "awayTeam": "New York Jets"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Minnesota Vikings",
+          "awayTeam": "Atlanta Falcons"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Giants",
+          "awayTeam": "New Orleans Saints"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Philadelphia Eagles",
+          "awayTeam": "Carolina Panthers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Pittsburgh Steelers",
+          "awayTeam": "Cleveland Browns"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tampa Bay Buccaneers",
+          "awayTeam": "Las Vegas Raiders"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Arizona Cardinals",
+          "awayTeam": "Seattle Seahawks"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Los Angeles Rams",
+          "awayTeam": "Buffalo Bills"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "San Francisco 49ers",
+          "awayTeam": "Chicago Bears"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Kansas City Chiefs",
+          "awayTeam": "Los Angeles Chargers"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Dallas Cowboys",
+          "awayTeam": "Cincinnati Bengals"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "15",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "San Francisco 49ers",
+          "awayTeam": "Los Angeles Rams"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Cleveland Browns",
+          "awayTeam": "Kansas City Chiefs"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tennessee Titans",
+          "awayTeam": "Cincinnati Bengals"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New Orleans Saints",
+          "awayTeam": "Washington Commanders"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Giants",
+          "awayTeam": "Baltimore Ravens"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Carolina Panthers",
+          "awayTeam": "Dallas Cowboys"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Jacksonville Jaguars",
+          "awayTeam": "New York Jets"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Houston Texans",
+          "awayTeam": "Miami Dolphins"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Denver Broncos",
+          "awayTeam": "Indianapolis Colts"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Detroit Lions",
+          "awayTeam": "Buffalo Bills"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Philadelphia Eagles",
+          "awayTeam": "Pittsburgh Steelers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Arizona Cardinals",
+          "awayTeam": "New England Patriots"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Los Angeles Chargers",
+          "awayTeam": "Tampa Bay Buccaneers"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Seattle Seahawks",
+          "awayTeam": "Green Bay Packers"
+        },
+        {
+          "day": "Mon",
+          "time": "8:00PM",
+          "homeTeam": "Minnesota Vikings",
+          "awayTeam": "Chicago Bears"
+        },
+        {
+          "day": "Mon",
+          "time": "8:30PM",
+          "homeTeam": "Las Vegas Raiders",
+          "awayTeam": "Atlanta Falcons"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "16",
+      "games": [
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "Cincinnati Bengals",
+          "awayTeam": "Cleveland Browns"
+        },
+        {
+          "day": "Sat",
+          "time": "1:00PM",
+          "homeTeam": "Kansas City Chiefs",
+          "awayTeam": "Houston Texans"
+        },
+        {
+          "day": "Sat",
+          "time": "4:30PM",
+          "homeTeam": "Baltimore Ravens",
+          "awayTeam": "Pittsburgh Steelers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Atlanta Falcons",
+          "awayTeam": "New York Giants"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Buffalo Bills",
+          "awayTeam": "New England Patriots"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Chicago Bears",
+          "awayTeam": "Detroit Lions"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Indianapolis Colts",
+          "awayTeam": "Tennessee Titans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Jets",
+          "awayTeam": "Los Angeles Rams"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Washington Commanders",
+          "awayTeam": "Philadelphia Eagles"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Carolina Panthers",
+          "awayTeam": "Arizona Cardinals"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Los Angeles Chargers",
+          "awayTeam": "Denver Broncos"
+        },
+        {
+          "day": "Sun",
+          "time": "4:05PM",
+          "homeTeam": "Seattle Seahawks",
+          "awayTeam": "Minnesota Vikings"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Las Vegas Raiders",
+          "awayTeam": "Jacksonville Jaguars"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Miami Dolphins",
+          "awayTeam": "San Francisco 49ers"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Dallas Cowboys",
+          "awayTeam": "Tampa Bay Buccaneers"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "Green Bay Packers",
+          "awayTeam": "New Orleans Saints"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "17",
+      "games": [
+        {
+          "day": "Wed",
+          "time": "1:00PM",
+          "homeTeam": "Pittsburgh Steelers",
+          "awayTeam": "Kansas City Chiefs"
+        },
+        {
+          "day": "Wed",
+          "time": "4:30PM",
+          "homeTeam": "Houston Texans",
+          "awayTeam": "Baltimore Ravens"
+        },
+        {
+          "day": "Thu",
+          "time": "8:15PM",
+          "homeTeam": "Chicago Bears",
+          "awayTeam": "Seattle Seahawks"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Cincinnati Bengals",
+          "awayTeam": "Denver Broncos"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New England Patriots",
+          "awayTeam": "Los Angeles Chargers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Giants",
+          "awayTeam": "Indianapolis Colts"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Washington Commanders",
+          "awayTeam": "Atlanta Falcons"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Buffalo Bills",
+          "awayTeam": "New York Jets"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Minnesota Vikings",
+          "awayTeam": "Green Bay Packers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New Orleans Saints",
+          "awayTeam": "Las Vegas Raiders"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tampa Bay Buccaneers",
+          "awayTeam": "Carolina Panthers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Jacksonville Jaguars",
+          "awayTeam": "Tennessee Titans"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Los Angeles Rams",
+          "awayTeam": "Arizona Cardinals"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Philadelphia Eagles",
+          "awayTeam": "Dallas Cowboys"
+        },
+        {
+          "day": "Sun",
+          "time": "8:20PM",
+          "homeTeam": "Cleveland Browns",
+          "awayTeam": "Miami Dolphins"
+        },
+        {
+          "day": "Mon",
+          "time": "8:15PM",
+          "homeTeam": "San Francisco 49ers",
+          "awayTeam": "Detroit Lions"
+        }
+      ]
+    },
+    {
+      "type": "season",
+      "number": "18",
+      "games": [
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Atlanta Falcons",
+          "awayTeam": "Carolina Panthers"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Dallas Cowboys",
+          "awayTeam": "Washington Commanders"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Detroit Lions",
+          "awayTeam": "Minnesota Vikings"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Green Bay Packers",
+          "awayTeam": "Chicago Bears"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tennessee Titans",
+          "awayTeam": "Houston Texans"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Indianapolis Colts",
+          "awayTeam": "Jacksonville Jaguars"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New England Patriots",
+          "awayTeam": "Buffalo Bills"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "New York Jets",
+          "awayTeam": "Miami Dolphins"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Philadelphia Eagles",
+          "awayTeam": "New York Giants"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Pittsburgh Steelers",
+          "awayTeam": "Cincinnati Bengals"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Tampa Bay Buccaneers",
+          "awayTeam": "New Orleans Saints"
+        },
+        {
+          "day": "Sun",
+          "time": "1:00PM",
+          "homeTeam": "Baltimore Ravens",
+          "awayTeam": "Cleveland Browns"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Denver Broncos",
+          "awayTeam": "Kansas City Chiefs"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Las Vegas Raiders",
+          "awayTeam": "Los Angeles Chargers"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Los Angeles Rams",
+          "awayTeam": "Seattle Seahawks"
+        },
+        {
+          "day": "Sun",
+          "time": "4:25PM",
+          "homeTeam": "Arizona Cardinals",
+          "awayTeam": "San Francisco 49ers"
+        }
+      ]
+    }
+  ]
+}

--- a/retroSchedules/transferRetroSchedule.js
+++ b/retroSchedules/transferRetroSchedule.js
@@ -20,12 +20,29 @@ console.log("This only works with Madden 24 Franchise Files, and if your Franchi
 
 const franchise = FranchiseUtils.selectFranchiseFile(gameYear,autoUnempty);
 
+let minYear = 1970;
+let maxYear = 2023;
+// Dynamically determine min and max year from folder
+const files = fs.readdirSync(directoryPath);
+const years = files.map(file => {
+  try
+  {
+    return parseInt(file.split('.')[0]);
+  }
+  catch (error)
+  {
+    return 0;
+  }
+});
+minYear = Math.min(...years);
+maxYear = Math.max(...years);
+
 async function promptUser() {
   let selectedYear;
 
   while (true) {
     // Ask the user for input
-    const inputYear = prompt('Enter the year of the schedule you would like to use (between 1970 and 2023): ');
+    const inputYear = prompt(`Enter the year of the schedule you would like to use (between ${minYear} and ${maxYear}): `);
 
     // Parse the input as an integer
     selectedYear = parseInt(inputYear, 10);
@@ -35,31 +52,35 @@ async function promptUser() {
         break;
     }
     // Check if the input is a valid year
-    if (!Number.isNaN(selectedYear) && selectedYear >= 1970 && selectedYear <= 2023) {
-      break; // Exit the loop if the input is valid
+    if (!Number.isNaN(selectedYear) && selectedYear >= minYear && selectedYear <= maxYear) 
+    {
+        break; // Exit the loop if the input is valid
     }
 
-    console.log('Invalid input. Please enter a year between 1970 and 2023.');
+    console.log(`Invalid input. Please enter a year between ${minYear} and ${maxYear}.`);
   }
 
   if (selectedYear === 0)
   {
-      // Custom JSON file case
-      const customJsonPath = prompt('Enter the full path of the custom JSON file: ');
-      try
-      {
-         const customJson = JSON.parse(fs.readFileSync(customJsonPath, 'utf8'));
-         return customJson;
-      }
-      catch (error)
-      {
-         console.error(`Error reading or parsing custom JSON file: `, error);
-      }
+    // Custom JSON file case
+    const customJsonPath = prompt('Enter the full path of the custom JSON file: ');
+    try
+    {
+      const customJson = JSON.parse(fs.readFileSync(customJsonPath, 'utf8'));
+      return customJson;
+    }
+    catch (error)
+    {
+      console.log(`Error reading or parsing custom JSON file: ${error}`);
+      console.log("Enter anything to exit.");
+      prompt();
+      process.exit(0);
+    }
   }
   else
   {
-     const sourceScheduleJson = await processSelectedYear(selectedYear);
-     return sourceScheduleJson;
+    const sourceScheduleJson = await processSelectedYear(selectedYear);
+    return sourceScheduleJson;
   }
   // Valid input, process the selected year
 }

--- a/scheduleExtractorM24/scheduleExtractorM24.js
+++ b/scheduleExtractorM24/scheduleExtractorM24.js
@@ -178,9 +178,20 @@ franchise.on('ready', async function () {
 				return day1Index - day2Index;
 			}
 
-			// If days are the same, compare times
-			const [hour1, minute1] = game1.time.split(":").map(Number);
-			const [hour2, minute2] = game2.time.split(":").map(Number);
+			// If days are the same, compare times, ensuring AM games come before PM games
+			const time1 = game1.time.split(':');
+			const time2 = game2.time.split(':');
+			const hour1 = parseInt(time1[0]);
+			const hour2 = parseInt(time2[0]);
+			const minute1 = parseInt(time1[1].substr(0, 2));
+			const minute2 = parseInt(time2[1].substr(0, 2));
+
+			const period1 = time1[1].substr(2);
+			const period2 = time2[1].substr(2);
+
+			if (period1 !== period2) {
+				return period1 === 'AM' ? -1 : 1;
+			}
 
 			if (hour1 !== hour2) {
 				return hour1 - hour2;


### PR DESCRIPTION
- Added the 2024 schedule to the retro schedule tool
- Updated the retro schedule tool to calculate the bounds for allowed years dynamically based on the JSONs in schedules (so adding a new schedule is as simple as adding it to the schedules folder and giving it the appropriate name)
- Fixed an issue with error handling in the custom JSON feature of the retro schedule tool
- Fixed an issue with the schedule extractor not sorting AM vs PM times properly.