### PR TITLE
Updates for schedule tool and update players with lookup tool

### DIFF
--- a/regenerateScheduleM24/regenerateScheduleM24.js
+++ b/regenerateScheduleM24/regenerateScheduleM24.js
@@ -177,20 +177,24 @@ async function getSuperBowlChampion(yearSummaryArray, yearSummary, teamTable)
 		}
 	}
 
-	let winningTeamRow;
-	for(let i = 0; i < teamTable.records.length; i++)
+	let winningTeamRow = -1;
+	let teamRows = Object.keys(teamLookup);
+	for (let i = 0; i < teamRows.length; i++)
 	{
-		if(teamTable.records[i].isEmpty)
+		if (teamLookup[teamRows[i]][0].includes(winningTeamName))
 		{
-			continue;
+			if(teamTable.records[teamRows[i]]['LongName'] === winningCityName)
+			{
+				winningTeamRow = teamRows[i];
+				break;
+			}
 		}
-		
-		// Check if both the city name and team name match
-		if (teamTable.records[i]['LongName'] === winningCityName && teamTable.records[i]['DisplayName'] === winningTeamName)
-		{
-			winningTeamRow = i;
-			break;
-		}
+	}
+
+	if(winningTeamRow === -1)
+	{
+		// If the winning team is not found for some reason, just use the first team row
+		winningTeamRow = 0;
 	}
 
 	let winningTeamAbbrev = rowToAbbrev(winningTeamRow);

--- a/updatePlayersWithLookup/buildExe.bat
+++ b/updatePlayersWithLookup/buildExe.bat
@@ -1,0 +1,1 @@
+nexe --build -i updatePlayersWithLookup.js -t x64-14.15.3 -r "../node_modules/madden-franchise/data/schemas" -r "../lookupFunctions/FranchiseUtils.js" -r "../lookupFunctions/FranchiseTableId.js" -r "../lookupFunctions/**/characterVisualsLookups/*" -o "updatePlayersWithLookup.exe" --verbose 

--- a/updatePlayersWithLookup/updatePlayersWithLookup.js
+++ b/updatePlayersWithLookup/updatePlayersWithLookup.js
@@ -5,6 +5,7 @@ const prompt = require('prompt-sync')();
 const Franchise = require('madden-franchise');
 const FranchiseUtils = require('../lookupFunctions/FranchiseUtils');
 const { tables } = require('../lookupFunctions/FranchiseTableId');
+const characterVisualFunctions = require('../lookupFunctions/characterVisualsLookups/characterVisualFunctions');
 
 // Print tool header message
 console.log("This program will update values for all players based on a lookup.\n")
@@ -20,6 +21,70 @@ const workbook = Xlsx.readFile(excelPath);
 const sheetName = workbook.SheetNames[0];
 const lookupData = Xlsx.utils.sheet_to_json(workbook.Sheets[sheetName]);
 
+// Ask user how many search columns they want to use
+let numSearchColumns = 1;
+console.log("How many lookup columns (to find players) do you want to use? Enter a number:");
+while (true) 
+{
+	numSearchColumns = parseInt(prompt().trim());
+	if (numSearchColumns > 0 && numSearchColumns <= Object.keys(lookupData[0]).length)
+	{
+		break;
+	}
+	else
+	{
+		console.log("Invalid input. Please enter a number between 1 and " + Object.keys(lookupData[0]).length + ".");
+	}
+}
+
+// Ask user if they would like to use AND or OR logic for the search columns
+let searchLogic = "AND";
+if(numSearchColumns > 1)
+{
+	console.log("Do you want to use AND or OR logic for the search columns? AND will require a match in all search columns, while OR will only require a match in at least one search column. Enter 'AND' or 'OR':");
+	while (true)
+	{
+		searchLogic = prompt().trim().toUpperCase();
+		if (searchLogic === 'AND' || searchLogic === 'OR')
+		{
+			break;
+		}
+		else
+		{
+			console.log("Invalid input. Please enter 'AND' or 'OR'.");
+		}
+	}
+}
+
+// Ask user if they want to update CharacterVisuals for edited players (if applicable)
+let updateVisuals = false;
+if(gameYear === '24')
+{
+	updateVisuals = getYesOrNo("Do you want to update CharacterVisuals for edited players? Choose yes if you will be updating any columns related to player appearance. (yes/no)");
+}
+
+function getYesOrNo(message) 
+{
+	while (true) 
+	{
+		console.log(message);
+		const input = prompt().trim().toUpperCase();
+  
+		if (input === 'YES') 
+		{
+			return true;
+		} 
+		else if (input === 'NO') 
+		{
+			return false;
+		} 
+		else 
+		{
+			console.log("Invalid input. Please enter yes or no.");
+		}
+	}
+}
+
 if (lookupData.length === 0)
 {
 	console.log("No data found in the lookup file.");
@@ -27,9 +92,9 @@ if (lookupData.length === 0)
 	prompt();
 	process.exit();
 }
-else if(Object.keys(lookupData[0]).length < 2)
+else if(Object.keys(lookupData[0]).length < (numSearchColumns + 1))
 {
-	console.log("Lookup file must have at least two columns.");
+	console.log(`Lookup file must have at least ${numSearchColumns + 1} columns.`);
 	console.log("Enter anything to exit.");
 	prompt();
 	process.exit();
@@ -37,20 +102,22 @@ else if(Object.keys(lookupData[0]).length < 2)
 
 franchise.on('ready', async function () {
     const playerTable = franchise.getTableByUniqueId(tables.playerTable);
+	const characterVisualsTable = franchise.getTableByUniqueId(tables.characterVisualsTable);
 
 	// Types of players that are not relevant for our purposes and can be skipped
 	const invalidStatuses = ['Draft','Retired','Deleted','None','Created'];
 
     await playerTable.readRecords();
+	await characterVisualsTable.readRecords();
 	
 	// Number of rows in the player table
     const numRows = playerTable.header.recordCapacity; 
 
-	// Get lookup column
-	const lookupColumn = Object.keys(lookupData[0])[0];
+	// Get lookup columns
+	const lookupColumns = Object.keys(lookupData[0]).slice(0, numSearchColumns);
 
 	// Get columns to update
-	const updateColumns = Object.keys(lookupData[0]).slice(1);
+	const updateColumns = Object.keys(lookupData[0]).slice(numSearchColumns);
 
 	// Iterate through the player table
     for (i = 0; i < numRows; i++) 
@@ -61,18 +128,33 @@ franchise.on('ready', async function () {
 			continue;
         }
 
-		// Get the player's lookup value
-		const lookupValue = playerTable.records[i][lookupColumn];
+		// Get each of the player's lookup values
+		const playerLookupValues = lookupColumns.map(column => playerTable.records[i][column]);
 
 		// Check if the lookup value exists in the lookup data
-		const lookupRow = lookupData.find(row => row[lookupColumn] === lookupValue);
+		let lookupValueExists = false;
+		if (searchLogic === 'AND')
+		{
+			lookupValueExists = playerLookupValues.every((value, index) => lookupData.some(row => row[lookupColumns[index]] === value));
+		}
+		else if (searchLogic === 'OR')
+		{
+			lookupValueExists = playerLookupValues.some((value, index) => lookupData.some(row => row[lookupColumns[index]] === value));
+		}
 
 		// If the lookup value exists, update the player's values
-		if (lookupRow)
+		if (lookupValueExists)
 		{
+			const lookupRow = lookupData.find(row => playerLookupValues.every((value, index) => row[lookupColumns[index]] === value));
 			updateColumns.forEach(column => {
 				playerTable.records[i][column] = lookupRow[column];
 			});
+
+			// Update CharacterVisuals for the player if applicable
+			if (updateVisuals)
+			{
+				await characterVisualFunctions.regeneratePlayerVisual(franchise, playerTable, characterVisualsTable, i, true);
+			}
 		}
 
     }


### PR DESCRIPTION
Schedule Regenerator:
- Fixed an issue when the Super Bowl champion is a relocation team

Update Players With Lookup:
- Added the ability to have multiple search columns
- Added AND/OR logic for search columns
- Added the option to regenerate CharacterVisuals for all edited players
- Added a build batch script