### PR TITLE
Character Visuals Functions - Updated logic for coaches with assetnames

### DIFF
--- a/lookupFunctions/characterVisualsLookups/characterVisualFunctions.js
+++ b/lookupFunctions/characterVisualsLookups/characterVisualFunctions.js
@@ -138,10 +138,21 @@ async function getCoachValues(coachTable, i) {
 };
 
 async function updateCoachVisuals(coachValues, jsonToUpdate,visualMorphKeys, size = "N/A") {
-  const [assetName, genericHeadName, firstName, lastName, height, skinTone] = coachValues;
+  let [assetName, genericHeadName, firstName, lastName, height, skinTone] = coachValues;
 
   // Get lookup values if they exist for this coach, OR get the default lookup values
-  const visualsLookup = allCoachVisuals[assetName] || allCoachVisuals["DefaultValue"];
+  let visualsLookup = allCoachVisuals["DefaultValue"];
+
+  if(allCoachVisuals.hasOwnProperty(assetName))
+  {
+    visualsLookup = allCoachVisuals[assetName];
+
+    // If lookup values exist for this coach, the genericHeadName needs to be MustBeUnique for the cyberface to work properly
+    genericHeadName = 'MustBeUnique';
+
+    // If the skintone is defined in the lookup, use it, otherwise keep the original value from the coach table
+    skinTone = visualsLookup['skinTone'] || skinTone;
+  }
 
   if (assetName === "") { // If no asset name, we can delete it from the json
     delete jsonToUpdate.assetName;

--- a/lookupFunctions/characterVisualsLookups/coachVisualsLookup.json
+++ b/lookupFunctions/characterVisualsLookups/coachVisualsLookup.json
@@ -1262,7 +1262,8 @@
     "GutBaseBlend": "1",
     "GutBarycentricBlend": "1",
     "ThighsBaseBlend": "1",
-    "ThighsBarycentricBlend": "1"
+    "ThighsBarycentricBlend": "1",
+    "skinTone": 7
   },
   "CowherBill_C_PRO": {
     "containerId": "374",


### PR DESCRIPTION
Updated the visuals functions with changes for coaches with assetname lookups:
- Skintone values are now pulled from the lookup JSON rather than the coach table. The coach table skintone value is still used as a fallback however.
- Generic head value is hardcoded to be MustBeUnique for coaches with assetname lookups to prevent issues with cyberfaces

The assetname lookups still need to be updated with a skintone value for each of the coaches, but this can be done gradually as the tool will still work without them, it will just fall back to the coach table values.