### PR TITLE
Schedule Transfer Tool/Schedule Extractor/Assign Vanity Gear - Several tweaks

### DIFF
--- a/assignVanityGear/buildExe.bat
+++ b/assignVanityGear/buildExe.bat
@@ -1,1 +1,1 @@
-nexe --build -i assignVanityGear.js -t x64-14.15.3 -r "../node_modules/madden-franchise/data/schemas" -r "../lookupFunctions/FranchiseUtils.js" -r "../lookupFunctions/FranchiseTableId.js" -r "lookupFiles/*.json" -o "assignVanityGear.exe" --verbose 
+nexe --build -i assignVanityGear.js -t x64-14.15.3 -r "../node_modules/madden-franchise/data/schemas" -r "../lookupFunctions/FranchiseUtils.js" -r "../lookupFunctions/FranchiseTableId.js" -r "lookupFiles/*.json" -r "../lookupFunctions/**/characterVisualsLookups/*" -o "assignVanityGear.exe" --verbose 

--- a/retroSchedules/schedules/2012.json
+++ b/retroSchedules/schedules/2012.json
@@ -1,1 +1,1643 @@
-{"year":"2012","weeks":[{"type":"season","number":"1","games":[{"day":"Wed","time":"8:41PM","homeTeam":"New York Giants","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Jets","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:03PM","homeTeam":"Detroit Lions","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:03PM","homeTeam":"Cleveland Browns","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:26PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"8:31PM","homeTeam":"Denver Broncos","awayTeam":"Pittsburgh Steelers"},{"day":"Mon","time":"7:10PM","homeTeam":"Baltimore Ravens","awayTeam":"Cincinnati Bengals"},{"day":"Mon","time":"10:25PM","homeTeam":"Oakland Raiders","awayTeam":"San Diego Chargers"}]},{"type":"season","number":"2","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Green Bay Packers","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:03PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Giants","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:03PM","homeTeam":"Philadelphia Eagles","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:03PM","homeTeam":"Indianapolis Colts","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"4:05PM","homeTeam":"St. Louis Rams","awayTeam":"Washington Redskins"},{"day":"Sun","time":"4:06PM","homeTeam":"Seattle Seahawks","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"4:25PM","homeTeam":"Pittsburgh Steelers","awayTeam":"New York Jets"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"8:30PM","homeTeam":"San Francisco 49ers","awayTeam":"Detroit Lions"},{"day":"Mon","time":"8:41PM","homeTeam":"Atlanta Falcons","awayTeam":"Denver Broncos"}]},{"type":"season","number":"3","games":[{"day":"Thu","time":"8:20PM","homeTeam":"Carolina Panthers","awayTeam":"New York Giants"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"New Orleans Saints","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:03PM","homeTeam":"Indianapolis Colts","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:03PM","homeTeam":"Miami Dolphins","awayTeam":"New York Jets"},{"day":"Sun","time":"1:04PM","homeTeam":"Chicago Bears","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:05PM","homeTeam":"Dallas Cowboys","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Houston Texans"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"8:31PM","homeTeam":"Baltimore Ravens","awayTeam":"New England Patriots"},{"day":"Mon","time":"8:41PM","homeTeam":"Seattle Seahawks","awayTeam":"Green Bay Packers"}]},{"type":"season","number":"4","games":[{"day":"Thu","time":"8:30PM","homeTeam":"Baltimore Ravens","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Jets","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:03PM","homeTeam":"Atlanta Falcons","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:03PM","homeTeam":"Detroit Lions","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"4:05PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"4:05PM","homeTeam":"Denver Broncos","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:25PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Washington Redskins"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"8:30PM","homeTeam":"Philadelphia Eagles","awayTeam":"New York Giants"},{"day":"Mon","time":"8:40PM","homeTeam":"Dallas Cowboys","awayTeam":"Chicago Bears"}]},{"type":"season","number":"5","games":[{"day":"Thu","time":"8:20PM","homeTeam":"St. Louis Rams","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Giants","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Kansas City Chiefs","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:03PM","homeTeam":"Indianapolis Colts","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:03PM","homeTeam":"Cincinnati Bengals","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:04PM","homeTeam":"Washington Redskins","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:04PM","homeTeam":"Carolina Panthers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:05PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Chicago Bears"},{"day":"Sun","time":"4:15PM","homeTeam":"Minnesota Vikings","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"4:25PM","homeTeam":"New England Patriots","awayTeam":"Denver Broncos"},{"day":"Sun","time":"8:31PM","homeTeam":"New Orleans Saints","awayTeam":"San Diego Chargers"},{"day":"Mon","time":"8:40PM","homeTeam":"New York Jets","awayTeam":"Houston Texans"}]},{"type":"season","number":"6","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Tennessee Titans","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:00PM","homeTeam":"Miami Dolphins","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:00PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:01PM","homeTeam":"Atlanta Falcons","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:03PM","homeTeam":"Philadelphia Eagles","awayTeam":"Detroit Lions"},{"day":"Sun","time":"4:04PM","homeTeam":"Seattle Seahawks","awayTeam":"New England Patriots"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"4:23PM","homeTeam":"San Francisco 49ers","awayTeam":"New York Giants"},{"day":"Sun","time":"4:24PM","homeTeam":"Washington Redskins","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"8:30PM","homeTeam":"Houston Texans","awayTeam":"Green Bay Packers"},{"day":"Mon","time":"8:40PM","homeTeam":"San Diego Chargers","awayTeam":"Denver Broncos"}]},{"type":"season","number":"7","games":[{"day":"Thu","time":"8:29PM","homeTeam":"San Francisco 49ers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:02PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Giants","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"4:25PM","homeTeam":"New England Patriots","awayTeam":"New York Jets"},{"day":"Sun","time":"8:30PM","homeTeam":"Cincinnati Bengals","awayTeam":"Pittsburgh Steelers"},{"day":"Mon","time":"8:40PM","homeTeam":"Chicago Bears","awayTeam":"Detroit Lions"}]},{"type":"season","number":"8","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Minnesota Vikings","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:03PM","homeTeam":"Philadelphia Eagles","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:03PM","homeTeam":"Chicago Bears","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:03PM","homeTeam":"Detroit Lions","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:05PM","homeTeam":"Green Bay Packers","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:06PM","homeTeam":"New York Jets","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:06PM","homeTeam":"Tennessee Titans","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:06PM","homeTeam":"Cleveland Browns","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:06PM","homeTeam":"St. Louis Rams","awayTeam":"New England Patriots"},{"day":"Sun","time":"4:06PM","homeTeam":"Kansas City Chiefs","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:25PM","homeTeam":"Dallas Cowboys","awayTeam":"New York Giants"},{"day":"Sun","time":"8:30PM","homeTeam":"Denver Broncos","awayTeam":"New Orleans Saints"},{"day":"Mon","time":"8:40PM","homeTeam":"Arizona Cardinals","awayTeam":"San Francisco 49ers"}]},{"type":"season","number":"9","games":[{"day":"Thu","time":"8:27PM","homeTeam":"San Diego Chargers","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:03PM","homeTeam":"Cleveland Browns","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:04PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:04PM","homeTeam":"Tennessee Titans","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:05PM","homeTeam":"Washington Redskins","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"4:06PM","homeTeam":"Seattle Seahawks","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"4:26PM","homeTeam":"New York Giants","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"8:31PM","homeTeam":"Atlanta Falcons","awayTeam":"Dallas Cowboys"},{"day":"Mon","time":"8:40PM","homeTeam":"New Orleans Saints","awayTeam":"Philadelphia Eagles"}]},{"type":"season","number":"10","games":[{"day":"Thu","time":"8:30PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"New Orleans Saints","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Carolina Panthers","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:03PM","homeTeam":"Miami Dolphins","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:03PM","homeTeam":"Cincinnati Bengals","awayTeam":"New York Giants"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"Detroit Lions"},{"day":"Sun","time":"4:06PM","homeTeam":"Seattle Seahawks","awayTeam":"New York Jets"},{"day":"Sun","time":"4:25PM","homeTeam":"Philadelphia Eagles","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"8:31PM","homeTeam":"Chicago Bears","awayTeam":"Houston Texans"},{"day":"Mon","time":"8:40PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Kansas City Chiefs"}]},{"type":"season","number":"11","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Buffalo Bills","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:03PM","homeTeam":"Atlanta Falcons","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:04PM","homeTeam":"Carolina Panthers","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:04PM","homeTeam":"Dallas Cowboys","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:25PM","homeTeam":"New England Patriots","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"8:30PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Baltimore Ravens"},{"day":"Mon","time":"8:40PM","homeTeam":"San Francisco 49ers","awayTeam":"Chicago Bears"}]},{"type":"season","number":"12","games":[{"day":"Thu","time":"12:39PM","homeTeam":"Detroit Lions","awayTeam":"Houston Texans"},{"day":"Thu","time":"4:41PM","homeTeam":"Dallas Cowboys","awayTeam":"Washington Redskins"},{"day":"Thu","time":"8:31PM","homeTeam":"New York Jets","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:03PM","homeTeam":"Indianapolis Colts","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:03PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:03PM","homeTeam":"Miami Dolphins","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"4:25PM","homeTeam":"New Orleans Saints","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"8:30PM","homeTeam":"New York Giants","awayTeam":"Green Bay Packers"},{"day":"Mon","time":"8:32PM","homeTeam":"Philadelphia Eagles","awayTeam":"Carolina Panthers"}]},{"type":"season","number":"13","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Atlanta Falcons","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Jets","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:03PM","homeTeam":"Chicago Bears","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:03PM","homeTeam":"Detroit Lions","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"4:05PM","homeTeam":"Denver Broncos","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:25PM","homeTeam":"Baltimore Ravens","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"8:20PM","homeTeam":"Dallas Cowboys","awayTeam":"Philadelphia Eagles"},{"day":"Mon","time":"8:40PM","homeTeam":"Washington Redskins","awayTeam":"New York Giants"}]},{"type":"season","number":"14","games":[{"day":"Thu","time":"8:30PM","homeTeam":"Oakland Raiders","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:03PM","homeTeam":"Cincinnati Bengals","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:04PM","homeTeam":"Carolina Panthers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"Chicago Bears"},{"day":"Sun","time":"4:05PM","homeTeam":"San Francisco 49ers","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"4:26PM","homeTeam":"New York Giants","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"8:30PM","homeTeam":"Green Bay Packers","awayTeam":"Detroit Lions"},{"day":"Mon","time":"8:40PM","homeTeam":"New England Patriots","awayTeam":"Houston Texans"}]},{"type":"season","number":"15","games":[{"day":"Thu","time":"8:30PM","homeTeam":"Philadelphia Eagles","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:03PM","homeTeam":"Chicago Bears","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:03PM","homeTeam":"Cleveland Browns","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:03PM","homeTeam":"Atlanta Falcons","awayTeam":"New York Giants"},{"day":"Sun","time":"1:03PM","homeTeam":"Miami Dolphins","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"Detroit Lions"},{"day":"Sun","time":"4:05PM","homeTeam":"Buffalo Bills","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:25PM","homeTeam":"Dallas Cowboys","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"8:30PM","homeTeam":"New England Patriots","awayTeam":"San Francisco 49ers"},{"day":"Mon","time":"8:40PM","homeTeam":"Tennessee Titans","awayTeam":"New York Jets"}]},{"type":"season","number":"16","games":[{"day":"Sat","time":"8:40PM","homeTeam":"Detroit Lions","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Dallas Cowboys","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Jets","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:03PM","homeTeam":"Philadelphia Eagles","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:04PM","homeTeam":"Carolina Panthers","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:05PM","homeTeam":"Denver Broncos","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:25PM","homeTeam":"Baltimore Ravens","awayTeam":"New York Giants"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Chicago Bears"},{"day":"Sun","time":"8:31PM","homeTeam":"Seattle Seahawks","awayTeam":"San Francisco 49ers"}]},{"type":"season","number":"17","games":[{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:03PM","homeTeam":"Detroit Lions","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:03PM","homeTeam":"Cincinnati Bengals","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:04PM","homeTeam":"New York Giants","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"4:21PM","homeTeam":"San Diego Chargers","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:25PM","homeTeam":"Minnesota Vikings","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"4:25PM","homeTeam":"New England Patriots","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"8:31PM","homeTeam":"Washington Redskins","awayTeam":"Dallas Cowboys"}]}]}
+{
+    "year": "2012",
+    "weeks": [
+        {
+            "type": "season",
+            "number": "1",
+            "games": [
+                {
+                    "day": "Wed",
+                    "time": "8:30PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "7:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Mon",
+                    "time": "10:15PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "San Diego Chargers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "2",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:20PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Denver Broncos"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "3",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:20PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Green Bay Packers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "4",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Chicago Bears"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "5",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:20PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Houston Texans"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "6",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:20PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Denver Broncos"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "7",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:20PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Detroit Lions"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "8",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:20PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "San Francisco 49ers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "9",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:20PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Philadelphia Eagles"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "10",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Kansas City Chiefs"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "11",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:20PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Chicago Bears"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "12",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "12:30PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Thu",
+                    "time": "4:15PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Carolina Panthers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "13",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:20PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:20PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "New York Giants"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "14",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Houston Texans"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "15",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "New York Jets"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "16",
+            "games": [
+                {
+                    "day": "Sat",
+                    "time": "8:30PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "San Francisco 49ers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "17",
+            "games": [
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:15PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Dallas Cowboys"
+                }
+            ]
+        }
+    ]
+}

--- a/retroSchedules/schedules/2013.json
+++ b/retroSchedules/schedules/2013.json
@@ -1,1 +1,1643 @@
-{"year":"2013","weeks":[{"type":"season","number":"1","games":[{"day":"Thu","time":"9:13PM","homeTeam":"Denver Broncos","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Jets","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:03PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:04PM","homeTeam":"Carolina Panthers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:23PM","homeTeam":"St. Louis Rams","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:26PM","homeTeam":"San Francisco 49ers","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"8:30PM","homeTeam":"Dallas Cowboys","awayTeam":"New York Giants"},{"day":"Mon","time":"7:10PM","homeTeam":"Washington Redskins","awayTeam":"Philadelphia Eagles"},{"day":"Mon","time":"10:25PM","homeTeam":"San Diego Chargers","awayTeam":"Houston Texans"}]},{"type":"season","number":"2","games":[{"day":"Thu","time":"8:29PM","homeTeam":"New England Patriots","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Kansas City Chiefs","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:03PM","homeTeam":"Chicago Bears","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:03PM","homeTeam":"Atlanta Falcons","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"Detroit Lions"},{"day":"Sun","time":"4:05PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:25PM","homeTeam":"New York Giants","awayTeam":"Denver Broncos"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"8:31PM","homeTeam":"Seattle Seahawks","awayTeam":"San Francisco 49ers"},{"day":"Mon","time":"8:41PM","homeTeam":"Cincinnati Bengals","awayTeam":"Pittsburgh Steelers"}]},{"type":"season","number":"3","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Philadelphia Eagles","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"Dallas Cowboys","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"New York Giants"},{"day":"Sun","time":"1:03PM","homeTeam":"Cincinnati Bengals","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:03PM","homeTeam":"Baltimore Ravens","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:05PM","homeTeam":"Miami Dolphins","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:25PM","homeTeam":"New York Jets","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"8:30PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Chicago Bears"},{"day":"Mon","time":"8:40PM","homeTeam":"Denver Broncos","awayTeam":"Oakland Raiders"}]},{"type":"season","number":"4","games":[{"day":"Thu","time":"8:25PM","homeTeam":"St. Louis Rams","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:02PM","homeTeam":"Kansas City Chiefs","awayTeam":"New York Giants"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:03PM","homeTeam":"Detroit Lions","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:06PM","homeTeam":"Cleveland Browns","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:06PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:07PM","homeTeam":"Minnesota Vikings","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"4:05PM","homeTeam":"Tennessee Titans","awayTeam":"New York Jets"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Washington Redskins"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"8:30PM","homeTeam":"Atlanta Falcons","awayTeam":"New England Patriots"},{"day":"Mon","time":"8:40PM","homeTeam":"New Orleans Saints","awayTeam":"Miami Dolphins"}]},{"type":"season","number":"5","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Cleveland Browns","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Giants","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:03PM","homeTeam":"Indianapolis Colts","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:25PM","homeTeam":"Dallas Cowboys","awayTeam":"Denver Broncos"},{"day":"Sun","time":"8:31PM","homeTeam":"San Francisco 49ers","awayTeam":"Houston Texans"},{"day":"Sun","time":"11:35PM","homeTeam":"Oakland Raiders","awayTeam":"San Diego Chargers"},{"day":"Mon","time":"8:40PM","homeTeam":"Atlanta Falcons","awayTeam":"New York Jets"}]},{"type":"season","number":"6","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Chicago Bears","awayTeam":"New York Giants"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:02PM","homeTeam":"Kansas City Chiefs","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Jets","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:05PM","homeTeam":"Denver Broncos","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"4:06PM","homeTeam":"Seattle Seahawks","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:25PM","homeTeam":"New England Patriots","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"8:31PM","homeTeam":"Dallas Cowboys","awayTeam":"Washington Redskins"},{"day":"Mon","time":"8:40PM","homeTeam":"San Diego Chargers","awayTeam":"Indianapolis Colts"}]},{"type":"season","number":"7","games":[{"day":"Thu","time":"8:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Jets","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:05PM","homeTeam":"Washington Redskins","awayTeam":"Chicago Bears"},{"day":"Sun","time":"4:06PM","homeTeam":"Tennessee Titans","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:25PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:26PM","homeTeam":"Kansas City Chiefs","awayTeam":"Houston Texans"},{"day":"Sun","time":"8:31PM","homeTeam":"Indianapolis Colts","awayTeam":"Denver Broncos"},{"day":"Mon","time":"8:40PM","homeTeam":"New York Giants","awayTeam":"Minnesota Vikings"}]},{"type":"season","number":"8","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"New York Giants"},{"day":"Sun","time":"1:02PM","homeTeam":"New Orleans Saints","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Kansas City Chiefs","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:03PM","homeTeam":"Detroit Lions","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:07PM","homeTeam":"Jacksonville Jaguars","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"4:06PM","homeTeam":"Cincinnati Bengals","awayTeam":"New York Jets"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Washington Redskins"},{"day":"Sun","time":"8:30PM","homeTeam":"Minnesota Vikings","awayTeam":"Green Bay Packers"},{"day":"Mon","time":"8:30PM","homeTeam":"St. Louis Rams","awayTeam":"Seattle Seahawks"}]},{"type":"season","number":"9","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Miami Dolphins","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:03PM","homeTeam":"Dallas Cowboys","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:04PM","homeTeam":"New York Jets","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:05PM","homeTeam":"Seattle Seahawks","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"4:25PM","homeTeam":"New England Patriots","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"4:25PM","homeTeam":"Cleveland Browns","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"8:30PM","homeTeam":"Houston Texans","awayTeam":"Indianapolis Colts"},{"day":"Mon","time":"8:40PM","homeTeam":"Green Bay Packers","awayTeam":"Chicago Bears"}]},{"type":"season","number":"10","games":[{"day":"Thu","time":"8:35PM","homeTeam":"Minnesota Vikings","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:03PM","homeTeam":"Atlanta Falcons","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Giants","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:03PM","homeTeam":"Indianapolis Colts","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:03PM","homeTeam":"Chicago Bears","awayTeam":"Detroit Lions"},{"day":"Sun","time":"4:05PM","homeTeam":"San Francisco 49ers","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Houston Texans"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Denver Broncos"},{"day":"Sun","time":"8:30PM","homeTeam":"New Orleans Saints","awayTeam":"Dallas Cowboys"},{"day":"Mon","time":"8:40PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Miami Dolphins"}]},{"type":"season","number":"11","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Tennessee Titans","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:04PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:05PM","homeTeam":"Miami Dolphins","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:25PM","homeTeam":"New Orleans Saints","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:25PM","homeTeam":"New York Giants","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"8:30PM","homeTeam":"Denver Broncos","awayTeam":"Kansas City Chiefs"},{"day":"Mon","time":"8:42PM","homeTeam":"Carolina Panthers","awayTeam":"New England Patriots"}]},{"type":"season","number":"12","games":[{"day":"Thu","time":"8:30PM","homeTeam":"Atlanta Falcons","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:03PM","homeTeam":"Detroit Lions","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:03PM","homeTeam":"Miami Dolphins","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:03PM","homeTeam":"Cleveland Browns","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"4:25PM","homeTeam":"New York Giants","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"8:30PM","homeTeam":"New England Patriots","awayTeam":"Denver Broncos"},{"day":"Mon","time":"8:40PM","homeTeam":"Washington Redskins","awayTeam":"San Francisco 49ers"}]},{"type":"season","number":"13","games":[{"day":"Thu","time":"12:36PM","homeTeam":"Detroit Lions","awayTeam":"Green Bay Packers"},{"day":"Thu","time":"4:31PM","homeTeam":"Dallas Cowboys","awayTeam":"Oakland Raiders"},{"day":"Thu","time":"8:31PM","homeTeam":"Baltimore Ravens","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:04PM","homeTeam":"Carolina Panthers","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"Chicago Bears"},{"day":"Sun","time":"4:05PM","homeTeam":"Buffalo Bills","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:05PM","homeTeam":"San Francisco 49ers","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"4:26PM","homeTeam":"Kansas City Chiefs","awayTeam":"Denver Broncos"},{"day":"Sun","time":"8:31PM","homeTeam":"Washington Redskins","awayTeam":"New York Giants"},{"day":"Mon","time":"8:41PM","homeTeam":"Seattle Seahawks","awayTeam":"New Orleans Saints"}]},{"type":"season","number":"14","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:02PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:03PM","homeTeam":"Baltimore Ravens","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:05PM","homeTeam":"Denver Broncos","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"New York Giants"},{"day":"Sun","time":"4:26PM","homeTeam":"San Francisco 49ers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"8:30PM","homeTeam":"New Orleans Saints","awayTeam":"Carolina Panthers"},{"day":"Mon","time":"8:40PM","homeTeam":"Chicago Bears","awayTeam":"Dallas Cowboys"}]},{"type":"season","number":"15","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Denver Broncos","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Minnesota Vikings","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:03PM","homeTeam":"Cleveland Browns","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:03PM","homeTeam":"Atlanta Falcons","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Giants","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:05PM","homeTeam":"Carolina Panthers","awayTeam":"New York Jets"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:25PM","homeTeam":"Dallas Cowboys","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"4:25PM","homeTeam":"St. Louis Rams","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:27PM","homeTeam":"Tennessee Titans","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"8:30PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Cincinnati Bengals"},{"day":"Mon","time":"8:40PM","homeTeam":"Detroit Lions","awayTeam":"Baltimore Ravens"}]},{"type":"season","number":"16","games":[{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Kansas City Chiefs","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:04PM","homeTeam":"Carolina Panthers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:05PM","homeTeam":"Detroit Lions","awayTeam":"New York Giants"},{"day":"Sun","time":"4:06PM","homeTeam":"Seattle Seahawks","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:25PM","homeTeam":"Baltimore Ravens","awayTeam":"New England Patriots"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"8:30PM","homeTeam":"Philadelphia Eagles","awayTeam":"Chicago Bears"},{"day":"Mon","time":"8:40PM","homeTeam":"San Francisco 49ers","awayTeam":"Atlanta Falcons"}]},{"type":"season","number":"17","games":[{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:04PM","homeTeam":"New York Giants","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:05PM","homeTeam":"Atlanta Falcons","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"Detroit Lions"},{"day":"Sun","time":"4:25PM","homeTeam":"New Orleans Saints","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"4:25PM","homeTeam":"New England Patriots","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Denver Broncos"},{"day":"Sun","time":"4:25PM","homeTeam":"Chicago Bears","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:26PM","homeTeam":"San Diego Chargers","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"8:30PM","homeTeam":"Dallas Cowboys","awayTeam":"Philadelphia Eagles"}]}]}
+{
+    "year": "2013",
+    "weeks": [
+        {
+            "type": "season",
+            "number": "1",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Mon",
+                    "time": "7:10PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Mon",
+                    "time": "10:20PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Houston Texans"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "2",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Pittsburgh Steelers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "3",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Oakland Raiders"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "4",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Miami Dolphins"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "5",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "10:20PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "New York Jets"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "6",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Indianapolis Colts"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "7",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Minnesota Vikings"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "8",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Seattle Seahawks"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "9",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Chicago Bears"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "10",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Miami Dolphins"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "11",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "New England Patriots"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "12",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "San Francisco 49ers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "13",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "12:30PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Thu",
+                    "time": "4:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "New Orleans Saints"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "14",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Dallas Cowboys"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "15",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Baltimore Ravens"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "16",
+            "games": [
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:40PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Atlanta Falcons"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "17",
+            "games": [
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Philadelphia Eagles"
+                }
+            ]
+        }
+    ]
+}

--- a/retroSchedules/schedules/2014.json
+++ b/retroSchedules/schedules/2014.json
@@ -1,1 +1,1643 @@
-{"year":"2014","weeks":[{"type":"season","number":"1","games":[{"day":"Thu","time":"8:42PM","homeTeam":"Seattle Seahawks","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Kansas City Chiefs","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:03PM","homeTeam":"Atlanta Falcons","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:03PM","homeTeam":"Miami Dolphins","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Washington Redskins"},{"day":"Sun","time":"4:25PM","homeTeam":"Dallas Cowboys","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:25PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"8:30PM","homeTeam":"Denver Broncos","awayTeam":"Indianapolis Colts"},{"day":"Mon","time":"7:11PM","homeTeam":"Detroit Lions","awayTeam":"New York Giants"},{"day":"Mon","time":"9:20PM","homeTeam":"Arizona Cardinals","awayTeam":"San Diego Chargers"}]},{"type":"season","number":"2","games":[{"day":"Thu","time":"8:28PM","homeTeam":"Baltimore Ravens","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:03PM","homeTeam":"Cleveland Browns","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:04PM","homeTeam":"New York Giants","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:04PM","homeTeam":"Carolina Panthers","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:05PM","homeTeam":"Washington Redskins","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:05PM","homeTeam":"Cincinnati Bengals","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:05PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"New York Jets"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Houston Texans"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"8:31PM","homeTeam":"San Francisco 49ers","awayTeam":"Chicago Bears"},{"day":"Mon","time":"8:31PM","homeTeam":"Indianapolis Colts","awayTeam":"Philadelphia Eagles"}]},{"type":"season","number":"3","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Atlanta Falcons","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Giants","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:25PM","homeTeam":"Seattle Seahawks","awayTeam":"Denver Broncos"},{"day":"Sun","time":"4:25PM","homeTeam":"Miami Dolphins","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"8:31PM","homeTeam":"Carolina Panthers","awayTeam":"Pittsburgh Steelers"},{"day":"Mon","time":"8:30PM","homeTeam":"New York Jets","awayTeam":"Chicago Bears"}]},{"type":"season","number":"4","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Washington Redskins","awayTeam":"New York Giants"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:03PM","homeTeam":"Indianapolis Colts","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:03PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:06PM","homeTeam":"Oakland Raiders","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"4:25PM","homeTeam":"Minnesota Vikings","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"8:31PM","homeTeam":"Dallas Cowboys","awayTeam":"New Orleans Saints"},{"day":"Mon","time":"8:31PM","homeTeam":"Kansas City Chiefs","awayTeam":"New England Patriots"}]},{"type":"season","number":"5","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Green Bay Packers","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Giants","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:03PM","homeTeam":"Dallas Cowboys","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:03PM","homeTeam":"Detroit Lions","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:03PM","homeTeam":"Indianapolis Colts","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"4:05PM","homeTeam":"Denver Broncos","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"New York Jets"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"8:43PM","homeTeam":"New England Patriots","awayTeam":"Cincinnati Bengals"},{"day":"Mon","time":"8:30PM","homeTeam":"Washington Redskins","awayTeam":"Seattle Seahawks"}]},{"type":"season","number":"6","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Houston Texans","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:02PM","homeTeam":"Minnesota Vikings","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:02PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:03PM","homeTeam":"Cincinnati Bengals","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Washington Redskins"},{"day":"Sun","time":"4:25PM","homeTeam":"Atlanta Falcons","awayTeam":"Chicago Bears"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"8:41PM","homeTeam":"Philadelphia Eagles","awayTeam":"New York Giants"},{"day":"Mon","time":"8:30PM","homeTeam":"St. Louis Rams","awayTeam":"San Francisco 49ers"}]},{"type":"season","number":"7","games":[{"day":"Thu","time":"8:25PM","homeTeam":"New England Patriots","awayTeam":"New York Jets"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:02PM","homeTeam":"Washington Redskins","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:25PM","homeTeam":"Dallas Cowboys","awayTeam":"New York Giants"},{"day":"Sun","time":"8:30PM","homeTeam":"Denver Broncos","awayTeam":"San Francisco 49ers"},{"day":"Mon","time":"8:30PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Houston Texans"}]},{"type":"season","number":"8","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Denver Broncos","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"9:37AM","homeTeam":"Atlanta Falcons","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:04PM","homeTeam":"Kansas City Chiefs","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:04PM","homeTeam":"Carolina Panthers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"4:25PM","homeTeam":"Cleveland Browns","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:25PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"8:30PM","homeTeam":"New Orleans Saints","awayTeam":"Green Bay Packers"},{"day":"Mon","time":"8:30PM","homeTeam":"Dallas Cowboys","awayTeam":"Washington Redskins"}]},{"type":"season","number":"9","games":[{"day":"Thu","time":"8:30PM","homeTeam":"Carolina Panthers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"New York Jets"},{"day":"Sun","time":"1:03PM","homeTeam":"Minnesota Vikings","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:04PM","homeTeam":"Dallas Cowboys","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:05PM","homeTeam":"San Francisco 49ers","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"4:25PM","homeTeam":"New England Patriots","awayTeam":"Denver Broncos"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"8:30PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Baltimore Ravens"},{"day":"Mon","time":"8:31PM","homeTeam":"New York Giants","awayTeam":"Indianapolis Colts"}]},{"type":"season","number":"10","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Cincinnati Bengals","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:03PM","homeTeam":"Baltimore Ravens","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:04PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:06PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Denver Broncos"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"New York Giants"},{"day":"Sun","time":"8:30PM","homeTeam":"Green Bay Packers","awayTeam":"Chicago Bears"},{"day":"Mon","time":"8:32PM","homeTeam":"Philadelphia Eagles","awayTeam":"Carolina Panthers"}]},{"type":"season","number":"11","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Miami Dolphins","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"New Orleans Saints","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Giants","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:03PM","homeTeam":"Cleveland Browns","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:04PM","homeTeam":"Kansas City Chiefs","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Detroit Lions"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"8:31PM","homeTeam":"Indianapolis Colts","awayTeam":"New England Patriots"},{"day":"Mon","time":"8:30PM","homeTeam":"Tennessee Titans","awayTeam":"Pittsburgh Steelers"}]},{"type":"season","number":"12","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Oakland Raiders","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:03PM","homeTeam":"Minnesota Vikings","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"4:06PM","homeTeam":"Seattle Seahawks","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Washington Redskins"},{"day":"Sun","time":"8:30PM","homeTeam":"New York Giants","awayTeam":"Dallas Cowboys"},{"day":"Mon","time":"7:05PM","homeTeam":"Buffalo Bills","awayTeam":"New York Jets"},{"day":"Mon","time":"8:30PM","homeTeam":"New Orleans Saints","awayTeam":"Baltimore Ravens"}]},{"type":"season","number":"13","games":[{"day":"Thu","time":"12:39PM","homeTeam":"Detroit Lions","awayTeam":"Chicago Bears"},{"day":"Thu","time":"4:36PM","homeTeam":"Dallas Cowboys","awayTeam":"Philadelphia Eagles"},{"day":"Thu","time":"8:31PM","homeTeam":"San Francisco 49ers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Minnesota Vikings","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:02PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:03PM","homeTeam":"Jacksonville Jaguars","awayTeam":"New York Giants"},{"day":"Sun","time":"4:05PM","homeTeam":"Atlanta Falcons","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"New England Patriots"},{"day":"Sun","time":"8:32PM","homeTeam":"Kansas City Chiefs","awayTeam":"Denver Broncos"},{"day":"Mon","time":"8:30PM","homeTeam":"New York Jets","awayTeam":"Miami Dolphins"}]},{"type":"season","number":"14","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Chicago Bears","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"Minnesota Vikings","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:03PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"New York Giants"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:03PM","homeTeam":"Cleveland Browns","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:05PM","homeTeam":"Denver Broncos","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"4:25PM","homeTeam":"Philadelphia Eagles","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"8:30PM","homeTeam":"San Diego Chargers","awayTeam":"New England Patriots"},{"day":"Mon","time":"8:30PM","homeTeam":"Green Bay Packers","awayTeam":"Atlanta Falcons"}]},{"type":"season","number":"15","games":[{"day":"Thu","time":"8:25PM","homeTeam":"St. Louis Rams","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Giants","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:05PM","homeTeam":"Tennessee Titans","awayTeam":"New York Jets"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Denver Broncos"},{"day":"Sun","time":"4:25PM","homeTeam":"Detroit Lions","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"8:35PM","homeTeam":"Philadelphia Eagles","awayTeam":"Dallas Cowboys"},{"day":"Mon","time":"8:30PM","homeTeam":"Chicago Bears","awayTeam":"New Orleans Saints"}]},{"type":"season","number":"16","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Tennessee Titans"},{"day":"Sat","time":"4:30PM","homeTeam":"Washington Redskins","awayTeam":"Philadelphia Eagles"},{"day":"Sat","time":"8:26PM","homeTeam":"San Francisco 49ers","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:03PM","homeTeam":"Miami Dolphins","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:03PM","homeTeam":"Chicago Bears","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:04PM","homeTeam":"Carolina Panthers","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:05PM","homeTeam":"St. Louis Rams","awayTeam":"New York Giants"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"4:26PM","homeTeam":"Dallas Cowboys","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"8:30PM","homeTeam":"Arizona Cardinals","awayTeam":"Seattle Seahawks"},{"day":"Mon","time":"8:30PM","homeTeam":"Cincinnati Bengals","awayTeam":"Denver Broncos"}]},{"type":"season","number":"17","games":[{"day":"Sun","time":"1:02PM","homeTeam":"New York Giants","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:02PM","homeTeam":"Minnesota Vikings","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"New York Jets"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:05PM","homeTeam":"Washington Redskins","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"Detroit Lions"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:25PM","homeTeam":"Atlanta Falcons","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:27PM","homeTeam":"Seattle Seahawks","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"8:30PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Cincinnati Bengals"}]}]}
+{
+    "year": "2014",
+    "weeks": [
+        {
+            "type": "season",
+            "number": "1",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Mon",
+                    "time": "7:10PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Mon",
+                    "time": "10:20PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "San Diego Chargers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "2",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Philadelphia Eagles"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "3",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Chicago Bears"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "4",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "New England Patriots"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "5",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Seattle Seahawks"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "6",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "San Francisco 49ers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "7",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Houston Texans"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "8",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "9:30AM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Washington Redskins"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "9",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Indianapolis Colts"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "10",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Carolina Panthers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "11",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Pittsburgh Steelers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "12",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Mon",
+                    "time": "4:30PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Baltimore Ravens"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "13",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "12:30PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Thu",
+                    "time": "4:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Miami Dolphins"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "14",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Atlanta Falcons"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "15",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "New Orleans Saints"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "16",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sat",
+                    "time": "4:30PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sat",
+                    "time": "8:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Denver Broncos"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "17",
+            "games": [
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Cincinnati Bengals"
+                }
+            ]
+        }
+    ]
+}

--- a/retroSchedules/schedules/2015.json
+++ b/retroSchedules/schedules/2015.json
@@ -1,1 +1,1643 @@
-{"year":"2015","weeks":[{"type":"season","number":"1","games":[{"day":"Thu","time":"8:40PM","homeTeam":"New England Patriots","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:02PM","homeTeam":"Washington Redskins","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:03PM","homeTeam":"Buffalo Bills","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:03PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:04PM","homeTeam":"New York Jets","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Detroit Lions"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"4:25PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"8:31PM","homeTeam":"Dallas Cowboys","awayTeam":"New York Giants"},{"day":"Mon","time":"7:10PM","homeTeam":"Atlanta Falcons","awayTeam":"Philadelphia Eagles"},{"day":"Mon","time":"10:20PM","homeTeam":"San Francisco 49ers","awayTeam":"Minnesota Vikings"}]},{"type":"season","number":"2","games":[{"day":"Thu","time":"8:29PM","homeTeam":"Kansas City Chiefs","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Giants","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:02PM","homeTeam":"New Orleans Saints","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Carolina Panthers","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:03PM","homeTeam":"Minnesota Vikings","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:03PM","homeTeam":"Cincinnati Bengals","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"4:05PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"4:25PM","homeTeam":"Philadelphia Eagles","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"8:25PM","homeTeam":"Green Bay Packers","awayTeam":"Seattle Seahawks"},{"day":"Mon","time":"8:30PM","homeTeam":"Indianapolis Colts","awayTeam":"New York Jets"}]},{"type":"season","number":"3","games":[{"day":"Thu","time":"8:26PM","homeTeam":"New York Giants","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:02PM","homeTeam":"Minnesota Vikings","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:03PM","homeTeam":"Dallas Cowboys","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Jets","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:06PM","homeTeam":"New England Patriots","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:25PM","homeTeam":"Miami Dolphins","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"Chicago Bears"},{"day":"Sun","time":"8:30PM","homeTeam":"Detroit Lions","awayTeam":"Denver Broncos"},{"day":"Mon","time":"8:30PM","homeTeam":"Green Bay Packers","awayTeam":"Kansas City Chiefs"}]},{"type":"season","number":"4","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"9:37AM","homeTeam":"Miami Dolphins","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"New York Giants"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:03PM","homeTeam":"Cincinnati Bengals","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"8:30PM","homeTeam":"New Orleans Saints","awayTeam":"Dallas Cowboys"},{"day":"Mon","time":"8:31PM","homeTeam":"Seattle Seahawks","awayTeam":"Detroit Lions"}]},{"type":"season","number":"5","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Houston Texans","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:02PM","homeTeam":"Kansas City Chiefs","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:02PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:03PM","homeTeam":"Cincinnati Bengals","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:04PM","homeTeam":"Philadelphia Eagles","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:05PM","homeTeam":"Detroit Lions","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:25PM","homeTeam":"Dallas Cowboys","awayTeam":"New England Patriots"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Denver Broncos"},{"day":"Sun","time":"8:31PM","homeTeam":"New York Giants","awayTeam":"San Francisco 49ers"},{"day":"Mon","time":"8:30PM","homeTeam":"San Diego Chargers","awayTeam":"Pittsburgh Steelers"}]},{"type":"season","number":"6","games":[{"day":"Thu","time":"8:26PM","homeTeam":"New Orleans Saints","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:02PM","homeTeam":"Minnesota Vikings","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:04PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:06PM","homeTeam":"Seattle Seahawks","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"8:30PM","homeTeam":"Indianapolis Colts","awayTeam":"New England Patriots"},{"day":"Mon","time":"8:30PM","homeTeam":"Philadelphia Eagles","awayTeam":"New York Giants"}]},{"type":"season","number":"7","games":[{"day":"Thu","time":"8:26PM","homeTeam":"San Francisco 49ers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"8:35AM","homeTeam":"Jacksonville Jaguars","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:03PM","homeTeam":"Indianapolis Colts","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:04PM","homeTeam":"Washington Redskins","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:25PM","homeTeam":"New York Giants","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"8:31PM","homeTeam":"Carolina Panthers","awayTeam":"Philadelphia Eagles"},{"day":"Mon","time":"8:30PM","homeTeam":"Arizona Cardinals","awayTeam":"Baltimore Ravens"}]},{"type":"season","number":"8","games":[{"day":"Thu","time":"8:26PM","homeTeam":"New England Patriots","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"9:36AM","homeTeam":"Kansas City Chiefs","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"New Orleans Saints","awayTeam":"New York Giants"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"New York Jets"},{"day":"Sun","time":"4:25PM","homeTeam":"Dallas Cowboys","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"8:30PM","homeTeam":"Denver Broncos","awayTeam":"Green Bay Packers"},{"day":"Mon","time":"8:30PM","homeTeam":"Carolina Panthers","awayTeam":"Indianapolis Colts"}]},{"type":"season","number":"9","games":[{"day":"Thu","time":"8:25PM","homeTeam":"Cincinnati Bengals","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Minnesota Vikings","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:02PM","homeTeam":"New Orleans Saints","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:04PM","homeTeam":"Carolina Panthers","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"4:05PM","homeTeam":"San Francisco 49ers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:05PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"New York Giants"},{"day":"Sun","time":"4:25PM","homeTeam":"Indianapolis Colts","awayTeam":"Denver Broncos"},{"day":"Sun","time":"8:31PM","homeTeam":"Dallas Cowboys","awayTeam":"Philadelphia Eagles"},{"day":"Mon","time":"8:30PM","homeTeam":"San Diego Chargers","awayTeam":"Chicago Bears"}]},{"type":"season","number":"10","games":[{"day":"Thu","time":"8:26PM","homeTeam":"New York Jets","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:03PM","homeTeam":"Tennessee Titans","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:04PM","homeTeam":"Green Bay Packers","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:04PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:05PM","homeTeam":"Philadelphia Eagles","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:05PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:05PM","homeTeam":"Baltimore Ravens","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:05PM","homeTeam":"Washington Redskins","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"4:30PM","homeTeam":"Denver Broncos","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:31PM","homeTeam":"New York Giants","awayTeam":"New England Patriots"},{"day":"Sun","time":"8:35PM","homeTeam":"Seattle Seahawks","awayTeam":"Arizona Cardinals"},{"day":"Mon","time":"8:30PM","homeTeam":"Cincinnati Bengals","awayTeam":"Houston Texans"}]},{"type":"season","number":"11","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"Carolina Panthers","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:03PM","homeTeam":"Miami Dolphins","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"New York Jets"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:25PM","homeTeam":"Minnesota Vikings","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"4:27PM","homeTeam":"Seattle Seahawks","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"8:30PM","homeTeam":"Arizona Cardinals","awayTeam":"Cincinnati Bengals"},{"day":"Mon","time":"8:30PM","homeTeam":"New England Patriots","awayTeam":"Buffalo Bills"}]},{"type":"season","number":"12","games":[{"day":"Thu","time":"12:35PM","homeTeam":"Detroit Lions","awayTeam":"Philadelphia Eagles"},{"day":"Thu","time":"4:31PM","homeTeam":"Dallas Cowboys","awayTeam":"Carolina Panthers"},{"day":"Thu","time":"8:30PM","homeTeam":"Green Bay Packers","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"New York Giants"},{"day":"Sun","time":"1:03PM","homeTeam":"Jacksonville Jaguars","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:05PM","homeTeam":"San Francisco 49ers","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"8:30PM","homeTeam":"Denver Broncos","awayTeam":"New England Patriots"},{"day":"Mon","time":"8:30PM","homeTeam":"Cleveland Browns","awayTeam":"Baltimore Ravens"}]},{"type":"season","number":"13","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Detroit Lions","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:00PM","homeTeam":"St. Louis Rams","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:02PM","homeTeam":"Minnesota Vikings","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:03PM","homeTeam":"Miami Dolphins","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Giants","awayTeam":"New York Jets"},{"day":"Sun","time":"1:03PM","homeTeam":"Cleveland Browns","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Denver Broncos"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:25PM","homeTeam":"New England Patriots","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"4:25PM","homeTeam":"New Orleans Saints","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"8:30PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Indianapolis Colts"},{"day":"Mon","time":"8:31PM","homeTeam":"Washington Redskins","awayTeam":"Dallas Cowboys"}]},{"type":"season","number":"14","games":[{"day":"Thu","time":"8:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:01PM","homeTeam":"Philadelphia Eagles","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"St. Louis Rams","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:05PM","homeTeam":"Denver Broncos","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"8:31PM","homeTeam":"Houston Texans","awayTeam":"New England Patriots"},{"day":"Mon","time":"8:30PM","homeTeam":"Miami Dolphins","awayTeam":"New York Giants"}]},{"type":"season","number":"15","games":[{"day":"Thu","time":"8:25PM","homeTeam":"St. Louis Rams","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sat","time":"8:26PM","homeTeam":"Dallas Cowboys","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Giants","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:02PM","homeTeam":"Minnesota Vikings","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"4:06PM","homeTeam":"Seattle Seahawks","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"4:25PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Denver Broncos"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"8:31PM","homeTeam":"Philadelphia Eagles","awayTeam":"Arizona Cardinals"},{"day":"Mon","time":"8:30PM","homeTeam":"New Orleans Saints","awayTeam":"Detroit Lions"}]},{"type":"season","number":"16","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Oakland Raiders","awayTeam":"San Diego Chargers"},{"day":"Sat","time":"8:26PM","homeTeam":"Philadelphia Eagles","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Jets","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:03PM","homeTeam":"Detroit Lions","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:03PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:05PM","homeTeam":"New Orleans Saints","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"8:30PM","homeTeam":"Minnesota Vikings","awayTeam":"New York Giants"},{"day":"Mon","time":"8:30PM","homeTeam":"Denver Broncos","awayTeam":"Cincinnati Bengals"}]},{"type":"season","number":"17","games":[{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Atlanta Falcons","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Giants","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:03PM","homeTeam":"Dallas Cowboys","awayTeam":"Washington Redskins"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"St. Louis Rams"},{"day":"Sun","time":"4:25PM","homeTeam":"Carolina Panthers","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"4:26PM","homeTeam":"Kansas City Chiefs","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"8:30PM","homeTeam":"Green Bay Packers","awayTeam":"Minnesota Vikings"}]}]}
+{
+    "year": "2015",
+    "weeks": [
+        {
+            "type": "season",
+            "number": "1",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Mon",
+                    "time": "7:10PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Mon",
+                    "time": "10:20PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Minnesota Vikings"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "2",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:25PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "New York Jets"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "3",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Kansas City Chiefs"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "4",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "9:30AM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Detroit Lions"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "5",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Pittsburgh Steelers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "6",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "New York Giants"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "7",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "9:30AM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Baltimore Ravens"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "8",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "9:30AM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Indianapolis Colts"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "9",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Chicago Bears"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "10",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:30PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:30PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Houston Texans"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "11",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Buffalo Bills"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "12",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "12:30PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Thu",
+                    "time": "4:30PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:30PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Baltimore Ravens"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "13",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Dallas Cowboys"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "14",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New York Giants"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "15",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "St. Louis Rams",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sat",
+                    "time": "8:25PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Detroit Lions"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "16",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sat",
+                    "time": "8:25PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Cincinnati Bengals"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "17",
+            "games": [
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "St. Louis Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Minnesota Vikings"
+                }
+            ]
+        }
+    ]
+}

--- a/retroSchedules/schedules/2016.json
+++ b/retroSchedules/schedules/2016.json
@@ -1,1 +1,2063 @@
-{"year":"2016","weeks":[{"type":"season","number":"1","games":[{"day":"Thu","time":"8:40PM","homeTeam":"Denver Broncos","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:04PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:04PM","homeTeam":"Baltimore Ravens","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:05PM","homeTeam":"Atlanta Falcons","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:05PM","homeTeam":"Tennessee Titans","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:05PM","homeTeam":"New Orleans Saints","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:05PM","homeTeam":"Philadelphia Eagles","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:05PM","homeTeam":"Kansas City Chiefs","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:05PM","homeTeam":"Houston Texans","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:05PM","homeTeam":"New York Jets","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"4:08PM","homeTeam":"Seattle Seahawks","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"4:27PM","homeTeam":"Dallas Cowboys","awayTeam":"New York Giants"},{"day":"Sun","time":"4:27PM","homeTeam":"Indianapolis Colts","awayTeam":"Detroit Lions"},{"day":"Sun","time":"8:30PM","homeTeam":"Arizona Cardinals","awayTeam":"New England Patriots"},{"day":"Mon","time":"7:11PM","homeTeam":"Washington Redskins","awayTeam":"Pittsburgh Steelers"},{"day":"Mon","time":"10:20PM","homeTeam":"San Francisco 49ers","awayTeam":"Los Angeles Rams"}]},{"type":"season","number":"2","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Buffalo Bills","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:03PM","homeTeam":"Carolina Panthers","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Giants","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:05PM","homeTeam":"Arizona Cardinals","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"4:08PM","homeTeam":"Los Angeles Rams","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"8:32PM","homeTeam":"Minnesota Vikings","awayTeam":"Green Bay Packers"},{"day":"Mon","time":"8:30PM","homeTeam":"Chicago Bears","awayTeam":"Philadelphia Eagles"}]},{"type":"season","number":"3","games":[{"day":"Thu","time":"8:26PM","homeTeam":"New England Patriots","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Giants","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Green Bay Packers","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:02PM","homeTeam":"Carolina Panthers","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Denver Broncos"},{"day":"Sun","time":"4:05PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Los Angeles Rams"},{"day":"Sun","time":"4:05PM","homeTeam":"Seattle Seahawks","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:25PM","homeTeam":"Philadelphia Eagles","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"4:25PM","homeTeam":"Indianapolis Colts","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:26PM","homeTeam":"Kansas City Chiefs","awayTeam":"New York Jets"},{"day":"Sun","time":"8:31PM","homeTeam":"Dallas Cowboys","awayTeam":"Chicago Bears"},{"day":"Mon","time":"8:30PM","homeTeam":"New Orleans Saints","awayTeam":"Atlanta Falcons"}]},{"type":"season","number":"4","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Cincinnati Bengals","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"9:35AM","homeTeam":"Jacksonville Jaguars","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Baltimore Ravens","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Houston Texans","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:03PM","homeTeam":"New York Jets","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:04PM","homeTeam":"Atlanta Falcons","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:05PM","homeTeam":"Washington Redskins","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"4:05PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Denver Broncos"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Los Angeles Rams"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"8:30PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Kansas City Chiefs"},{"day":"Mon","time":"8:35PM","homeTeam":"Minnesota Vikings","awayTeam":"New York Giants"}]},{"type":"season","number":"5","games":[{"day":"Thu","time":"8:27PM","homeTeam":"San Francisco 49ers","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:02PM","homeTeam":"Pittsburgh Steelers","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:03PM","homeTeam":"Baltimore Ravens","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:05PM","homeTeam":"Minnesota Vikings","awayTeam":"Houston Texans"},{"day":"Sun","time":"4:05PM","homeTeam":"Denver Broncos","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:25PM","homeTeam":"Los Angeles Rams","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:25PM","homeTeam":"Dallas Cowboys","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"8:30PM","homeTeam":"Green Bay Packers","awayTeam":"New York Giants"},{"day":"Mon","time":"8:04PM","homeTeam":"Carolina Panthers","awayTeam":"Tampa Bay Buccaneers"}]},{"type":"season","number":"6","games":[{"day":"Thu","time":"8:25PM","homeTeam":"San Diego Chargers","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Los Angeles Rams"},{"day":"Sun","time":"1:02PM","homeTeam":"Chicago Bears","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:02PM","homeTeam":"New England Patriots","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:02PM","homeTeam":"New York Giants","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:03PM","homeTeam":"Washington Redskins","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"4:26PM","homeTeam":"Seattle Seahawks","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"8:32PM","homeTeam":"Houston Texans","awayTeam":"Indianapolis Colts"},{"day":"Mon","time":"8:30PM","homeTeam":"Arizona Cardinals","awayTeam":"New York Jets"}]},{"type":"season","number":"7","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Green Bay Packers","awayTeam":"Chicago Bears"},{"day":"Sun","time":"9:31AM","homeTeam":"Los Angeles Rams","awayTeam":"New York Giants"},{"day":"Sun","time":"1:02PM","homeTeam":"Philadelphia Eagles","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:02PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Tennessee Titans","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:02PM","homeTeam":"Miami Dolphins","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:02PM","homeTeam":"Detroit Lions","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:02PM","homeTeam":"Cincinnati Bengals","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:03PM","homeTeam":"Kansas City Chiefs","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:04PM","homeTeam":"New York Jets","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"4:05PM","homeTeam":"Atlanta Falcons","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:05PM","homeTeam":"San Francisco 49ers","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"4:25PM","homeTeam":"Pittsburgh Steelers","awayTeam":"New England Patriots"},{"day":"Sun","time":"8:30PM","homeTeam":"Arizona Cardinals","awayTeam":"Seattle Seahawks"},{"day":"Mon","time":"8:30PM","homeTeam":"Denver Broncos","awayTeam":"Houston Texans"}]},{"type":"season","number":"8","games":[{"day":"Thu","time":"8:26PM","homeTeam":"Tennessee Titans","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"8:36AM","homeTeam":"Cincinnati Bengals","awayTeam":"Washington Redskins"},{"day":"Sun","time":"12:47PM","homeTeam":"Carolina Panthers","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:02PM","homeTeam":"Buffalo Bills","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:02PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:02PM","homeTeam":"Cleveland Browns","awayTeam":"New York Jets"},{"day":"Sun","time":"1:02PM","homeTeam":"Indianapolis Colts","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:03PM","homeTeam":"New Orleans Saints","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"1:03PM","homeTeam":"Houston Texans","awayTeam":"Detroit Lions"},{"day":"Sun","time":"4:05PM","homeTeam":"Denver Broncos","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"4:25PM","homeTeam":"Atlanta Falcons","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"8:31PM","homeTeam":"Dallas Cowboys","awayTeam":"Philadelphia Eagles"},{"day":"Mon","time":"8:31PM","homeTeam":"Chicago Bears","awayTeam":"Minnesota Vikings"}]},{"type":"season","number":"9","games":[{"day":"Thu","time":"8:25PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"1:00PM","homeTeam":"Baltimore Ravens","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:00PM","homeTeam":"Miami Dolphins","awayTeam":"New York Jets"},{"day":"Sun","time":"1:00PM","homeTeam":"New York Giants","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:00PM","homeTeam":"Kansas City Chiefs","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:00PM","homeTeam":"Minnesota Vikings","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:00PM","homeTeam":"Cleveland Browns","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"4:05PM","homeTeam":"San Francisco 49ers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:05PM","homeTeam":"Los Angeles Rams","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"8:30PM","homeTeam":"Oakland Raiders","awayTeam":"Denver Broncos"},{"day":"Mon","time":"8:30PM","homeTeam":"Seattle Seahawks","awayTeam":"Buffalo Bills"}]},{"type":"season","number":"10","games":[{"day":"Thu","time":"8:25PM","homeTeam":"Baltimore Ravens","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:00PM","homeTeam":"Carolina Panthers","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:00PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:00PM","homeTeam":"Washington Redskins","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:00PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:00PM","homeTeam":"Tennessee Titans","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:00PM","homeTeam":"New York Jets","awayTeam":"Los Angeles Rams"},{"day":"Sun","time":"1:00PM","homeTeam":"New Orleans Saints","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:00PM","homeTeam":"Philadelphia Eagles","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:05PM","homeTeam":"San Diego Chargers","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:25PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"8:30PM","homeTeam":"New England Patriots","awayTeam":"Seattle Seahawks"},{"day":"Mon","time":"8:30PM","homeTeam":"New York Giants","awayTeam":"Cincinnati Bengals"}]},{"type":"season","number":"11","games":[{"day":"Thu","time":"8:25PM","homeTeam":"Carolina Panthers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"1:00PM","homeTeam":"Cincinnati Bengals","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:00PM","homeTeam":"Detroit Lions","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:00PM","homeTeam":"New York Giants","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:00PM","homeTeam":"Minnesota Vikings","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:00PM","homeTeam":"Dallas Cowboys","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"1:00PM","homeTeam":"Kansas City Chiefs","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"1:00PM","homeTeam":"Indianapolis Colts","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:00PM","homeTeam":"Cleveland Browns","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"4:05PM","homeTeam":"Los Angeles Rams","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"New England Patriots"},{"day":"Sun","time":"4:25PM","homeTeam":"Seattle Seahawks","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"8:30PM","homeTeam":"Washington Redskins","awayTeam":"Green Bay Packers"},{"day":"Mon","time":"8:30PM","homeTeam":"Oakland Raiders","awayTeam":"Houston Texans"}]},{"type":"season","number":"12","games":[{"day":"Thu","time":"12:30PM","homeTeam":"Detroit Lions","awayTeam":"Minnesota Vikings"},{"day":"Thu","time":"4:30PM","homeTeam":"Dallas Cowboys","awayTeam":"Washington Redskins"},{"day":"Thu","time":"8:30PM","homeTeam":"Indianapolis Colts","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:00PM","homeTeam":"Atlanta Falcons","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:00PM","homeTeam":"Houston Texans","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:00PM","homeTeam":"Baltimore Ravens","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:00PM","homeTeam":"Miami Dolphins","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:00PM","homeTeam":"New Orleans Saints","awayTeam":"Los Angeles Rams"},{"day":"Sun","time":"1:00PM","homeTeam":"Buffalo Bills","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"1:00PM","homeTeam":"Cleveland Browns","awayTeam":"New York Giants"},{"day":"Sun","time":"4:05PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"4:25PM","homeTeam":"Oakland Raiders","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"4:25PM","homeTeam":"New York Jets","awayTeam":"New England Patriots"},{"day":"Sun","time":"8:30PM","homeTeam":"Denver Broncos","awayTeam":"Kansas City Chiefs"},{"day":"Mon","time":"8:30PM","homeTeam":"Philadelphia Eagles","awayTeam":"Green Bay Packers"}]},{"type":"season","number":"13","games":[{"day":"Thu","time":"7:25PM","homeTeam":"Minnesota Vikings","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:00PM","homeTeam":"Baltimore Ravens","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:00PM","homeTeam":"New England Patriots","awayTeam":"Los Angeles Rams"},{"day":"Sun","time":"1:00PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:00PM","homeTeam":"New Orleans Saints","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"1:00PM","homeTeam":"Green Bay Packers","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:00PM","homeTeam":"Atlanta Falcons","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"1:00PM","homeTeam":"Cincinnati Bengals","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"4:25PM","homeTeam":"Arizona Cardinals","awayTeam":"Washington Redskins"},{"day":"Sun","time":"4:25PM","homeTeam":"Pittsburgh Steelers","awayTeam":"New York Giants"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sun","time":"8:30PM","homeTeam":"Seattle Seahawks","awayTeam":"Carolina Panthers"},{"day":"Mon","time":"8:30PM","homeTeam":"New York Jets","awayTeam":"Indianapolis Colts"}]},{"type":"season","number":"14","games":[{"day":"Thu","time":"8:25PM","homeTeam":"Kansas City Chiefs","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"1:00PM","homeTeam":"Indianapolis Colts","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:00PM","homeTeam":"Carolina Panthers","awayTeam":"San Diego Chargers"},{"day":"Sun","time":"1:00PM","homeTeam":"Cleveland Browns","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"1:00PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Minnesota Vikings"},{"day":"Sun","time":"1:00PM","homeTeam":"Miami Dolphins","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"1:00PM","homeTeam":"Buffalo Bills","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:00PM","homeTeam":"Tennessee Titans","awayTeam":"Denver Broncos"},{"day":"Sun","time":"1:00PM","homeTeam":"Philadelphia Eagles","awayTeam":"Washington Redskins"},{"day":"Sun","time":"1:00PM","homeTeam":"Detroit Lions","awayTeam":"Chicago Bears"},{"day":"Sun","time":"4:05PM","homeTeam":"San Francisco 49ers","awayTeam":"New York Jets"},{"day":"Sun","time":"4:25PM","homeTeam":"Los Angeles Rams","awayTeam":"Atlanta Falcons"},{"day":"Sun","time":"4:25PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:25PM","homeTeam":"Green Bay Packers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"8:30PM","homeTeam":"New York Giants","awayTeam":"Dallas Cowboys"},{"day":"Mon","time":"8:30PM","homeTeam":"New England Patriots","awayTeam":"Baltimore Ravens"}]},{"type":"season","number":"15","games":[{"day":"Thu","time":"8:25PM","homeTeam":"Seattle Seahawks","awayTeam":"Los Angeles Rams"},{"day":"Sat","time":"8:25PM","homeTeam":"New York Jets","awayTeam":"Miami Dolphins"},{"day":"Sun","time":"1:00PM","homeTeam":"Buffalo Bills","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:00PM","homeTeam":"Baltimore Ravens","awayTeam":"Philadelphia Eagles"},{"day":"Sun","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"Green Bay Packers"},{"day":"Sun","time":"1:00PM","homeTeam":"Minnesota Vikings","awayTeam":"Indianapolis Colts"},{"day":"Sun","time":"1:00PM","homeTeam":"New York Giants","awayTeam":"Detroit Lions"},{"day":"Sun","time":"1:00PM","homeTeam":"Houston Texans","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:00PM","homeTeam":"Cincinnati Bengals","awayTeam":"Pittsburgh Steelers"},{"day":"Sun","time":"1:00PM","homeTeam":"Kansas City Chiefs","awayTeam":"Tennessee Titans"},{"day":"Sun","time":"4:05PM","homeTeam":"Arizona Cardinals","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:05PM","homeTeam":"Atlanta Falcons","awayTeam":"San Francisco 49ers"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"New England Patriots"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"8:30PM","homeTeam":"Dallas Cowboys","awayTeam":"Tampa Bay Buccaneers"},{"day":"Mon","time":"8:30PM","homeTeam":"Washington Redskins","awayTeam":"Carolina Panthers"}]},{"type":"season","number":"16","games":[{"day":"Thu","time":"8:25PM","homeTeam":"Philadelphia Eagles","awayTeam":"New York Giants"},{"day":"Sat","time":"1:00PM","homeTeam":"Carolina Panthers","awayTeam":"Atlanta Falcons"},{"day":"Sat","time":"1:00PM","homeTeam":"New England Patriots","awayTeam":"New York Jets"},{"day":"Sat","time":"1:00PM","homeTeam":"Green Bay Packers","awayTeam":"Minnesota Vikings"},{"day":"Sat","time":"1:00PM","homeTeam":"Buffalo Bills","awayTeam":"Miami Dolphins"},{"day":"Sat","time":"1:00PM","homeTeam":"Chicago Bears","awayTeam":"Washington Redskins"},{"day":"Sat","time":"1:00PM","homeTeam":"Jacksonville Jaguars","awayTeam":"Tennessee Titans"},{"day":"Sat","time":"1:00PM","homeTeam":"Cleveland Browns","awayTeam":"San Diego Chargers"},{"day":"Sat","time":"4:05PM","homeTeam":"Oakland Raiders","awayTeam":"Indianapolis Colts"},{"day":"Sat","time":"4:25PM","homeTeam":"Los Angeles Rams","awayTeam":"San Francisco 49ers"},{"day":"Sat","time":"4:25PM","homeTeam":"New Orleans Saints","awayTeam":"Tampa Bay Buccaneers"},{"day":"Sat","time":"4:25PM","homeTeam":"Seattle Seahawks","awayTeam":"Arizona Cardinals"},{"day":"Sat","time":"8:25PM","homeTeam":"Houston Texans","awayTeam":"Cincinnati Bengals"},{"day":"Sun","time":"4:30PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"8:30PM","homeTeam":"Kansas City Chiefs","awayTeam":"Denver Broncos"},{"day":"Mon","time":"8:30PM","homeTeam":"Dallas Cowboys","awayTeam":"Detroit Lions"}]},{"type":"season","number":"17","games":[{"day":"Sun","time":"1:00PM","homeTeam":"Miami Dolphins","awayTeam":"New England Patriots"},{"day":"Sun","time":"1:00PM","homeTeam":"New York Jets","awayTeam":"Buffalo Bills"},{"day":"Sun","time":"1:00PM","homeTeam":"Tampa Bay Buccaneers","awayTeam":"Carolina Panthers"},{"day":"Sun","time":"1:00PM","homeTeam":"Minnesota Vikings","awayTeam":"Chicago Bears"},{"day":"Sun","time":"1:00PM","homeTeam":"Tennessee Titans","awayTeam":"Houston Texans"},{"day":"Sun","time":"1:00PM","homeTeam":"Pittsburgh Steelers","awayTeam":"Cleveland Browns"},{"day":"Sun","time":"1:00PM","homeTeam":"Indianapolis Colts","awayTeam":"Jacksonville Jaguars"},{"day":"Sun","time":"1:00PM","homeTeam":"Philadelphia Eagles","awayTeam":"Dallas Cowboys"},{"day":"Sun","time":"1:00PM","homeTeam":"Cincinnati Bengals","awayTeam":"Baltimore Ravens"},{"day":"Sun","time":"4:25PM","homeTeam":"Los Angeles Rams","awayTeam":"Arizona Cardinals"},{"day":"Sun","time":"4:25PM","homeTeam":"Washington Redskins","awayTeam":"New York Giants"},{"day":"Sun","time":"4:25PM","homeTeam":"Denver Broncos","awayTeam":"Oakland Raiders"},{"day":"Sun","time":"4:25PM","homeTeam":"San Diego Chargers","awayTeam":"Kansas City Chiefs"},{"day":"Sun","time":"4:25PM","homeTeam":"Atlanta Falcons","awayTeam":"New Orleans Saints"},{"day":"Sun","time":"4:25PM","homeTeam":"San Francisco 49ers","awayTeam":"Seattle Seahawks"},{"day":"Sun","time":"8:30PM","homeTeam":"Detroit Lions","awayTeam":"Green Bay Packers"}]}]}
+{
+    "year": "2016",
+    "weeks": [
+        {
+            "type": "preseason",
+            "number": "1",
+            "games": [
+                {
+                    "day": "Sun",
+                    "time": "8:00 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Green Bay Packers"
+                }
+            ]
+        },
+        {
+            "type": "preseason",
+            "number": "2",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "7:00 PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:00 PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:30 PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:30 PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:30 PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:00 PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Fri",
+                    "time": "7:00 PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Fri",
+                    "time": "7:30 PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Fri",
+                    "time": "7:30 PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Fri",
+                    "time": "8:00 PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sat",
+                    "time": "4:30 PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sat",
+                    "time": "7:00 PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sat",
+                    "time": "8:00 PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sat",
+                    "time": "8:00 PM",
+                    "homeTeam": "Los Angeles Rams",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sat",
+                    "time": "10:00 PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "7:00 PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Houston Texans"
+                }
+            ]
+        },
+        {
+            "type": "preseason",
+            "number": "3",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "7:00 PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:30 PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:00 PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:00 PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:00 PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Fri",
+                    "time": "7:30 PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Fri",
+                    "time": "10:00 PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sat",
+                    "time": "3:00 PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sat",
+                    "time": "4:00 PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sat",
+                    "time": "7:00 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sat",
+                    "time": "7:30 PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sat",
+                    "time": "8:00 PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sat",
+                    "time": "9:00 PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sat",
+                    "time": "10:00 PM",
+                    "homeTeam": "Los Angeles Rams",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "9:00 PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "7:00 PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Miami Dolphins"
+                }
+            ]
+        },
+        {
+            "type": "preseason",
+            "number": "4",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:00 PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Fri",
+                    "time": "7:30 PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Fri",
+                    "time": "8:00 PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Fri",
+                    "time": "8:00 PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Fri",
+                    "time": "10:00 PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sat",
+                    "time": "1:00 PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sat",
+                    "time": "7:00 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sat",
+                    "time": "7:00 PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sat",
+                    "time": "7:00 PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sat",
+                    "time": "7:30 PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sat",
+                    "time": "8:00 PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sat",
+                    "time": "9:30 PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:00 PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:00 PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "9:00 PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Los Angeles Rams"
+                }
+            ]
+        },
+        {
+            "type": "preseason",
+            "number": "5",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "7:00 PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:00 PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:00 PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:00 PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:30 PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:30 PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:30 PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Thu",
+                    "time": "7:30 PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:00 PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:00 PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:00 PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:00 PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Los Angeles Rams"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:00 PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Fri",
+                    "time": "9:30 PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Fri",
+                    "time": "10:00 PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Fri",
+                    "time": "10:00 PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "San Francisco 49ers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "1",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:30 PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Mon",
+                    "time": "7:10 PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "10:20 PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Los Angeles Rams"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "2",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Los Angeles Rams",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Philadelphia Eagles"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "3",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Los Angeles Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Atlanta Falcons"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "4",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "9:30 AM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Los Angeles Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "New York Giants"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "5",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Los Angeles Rams",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "6",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Los Angeles Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "New York Jets"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "7",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "9:30 AM",
+                    "homeTeam": "Los Angeles Rams",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Houston Texans"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "8",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "9:30 AM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Minnesota Vikings"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "9",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Los Angeles Rams",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Buffalo Bills"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "10",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Los Angeles Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Cincinnati Bengals"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "11",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Los Angeles Rams",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Houston Texans"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "12",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "12:30 PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Thu",
+                    "time": "4:30 PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Thu",
+                    "time": "8:30 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Los Angeles Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Green Bay Packers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "13",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Los Angeles Rams"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Indianapolis Colts"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "14",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Seattle Seahawks"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Los Angeles Rams",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "Baltimore Ravens"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "15",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Los Angeles Rams"
+                },
+                {
+                    "day": "Sat",
+                    "time": "8:25 PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Giants",
+                    "awayTeam": "Detroit Lions"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Baltimore Ravens",
+                    "awayTeam": "Philadelphia Eagles"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:05 PM",
+                    "homeTeam": "Arizona Cardinals",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Pittsburgh Steelers"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "Carolina Panthers"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "16",
+            "games": [
+                {
+                    "day": "Thu",
+                    "time": "8:25 PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sat",
+                    "time": "1:00 PM",
+                    "homeTeam": "Buffalo Bills",
+                    "awayTeam": "Miami Dolphins"
+                },
+                {
+                    "day": "Sat",
+                    "time": "1:00 PM",
+                    "homeTeam": "Carolina Panthers",
+                    "awayTeam": "Atlanta Falcons"
+                },
+                {
+                    "day": "Sat",
+                    "time": "1:00 PM",
+                    "homeTeam": "Chicago Bears",
+                    "awayTeam": "Washington Redskins"
+                },
+                {
+                    "day": "Sat",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cleveland Browns",
+                    "awayTeam": "San Diego Chargers"
+                },
+                {
+                    "day": "Sat",
+                    "time": "1:00 PM",
+                    "homeTeam": "Green Bay Packers",
+                    "awayTeam": "Minnesota Vikings"
+                },
+                {
+                    "day": "Sat",
+                    "time": "1:00 PM",
+                    "homeTeam": "Jacksonville Jaguars",
+                    "awayTeam": "Tennessee Titans"
+                },
+                {
+                    "day": "Sat",
+                    "time": "1:00 PM",
+                    "homeTeam": "New Orleans Saints",
+                    "awayTeam": "Tampa Bay Buccaneers"
+                },
+                {
+                    "day": "Sat",
+                    "time": "1:00 PM",
+                    "homeTeam": "New England Patriots",
+                    "awayTeam": "New York Jets"
+                },
+                {
+                    "day": "Sat",
+                    "time": "4:05 PM",
+                    "homeTeam": "Oakland Raiders",
+                    "awayTeam": "Indianapolis Colts"
+                },
+                {
+                    "day": "Sat",
+                    "time": "4:25 PM",
+                    "homeTeam": "Los Angeles Rams",
+                    "awayTeam": "San Francisco 49ers"
+                },
+                {
+                    "day": "Sat",
+                    "time": "4:25 PM",
+                    "homeTeam": "Seattle Seahawks",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sat",
+                    "time": "8:25 PM",
+                    "homeTeam": "Houston Texans",
+                    "awayTeam": "Cincinnati Bengals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:30 PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "8:30 PM",
+                    "homeTeam": "Kansas City Chiefs",
+                    "awayTeam": "Denver Broncos"
+                },
+                {
+                    "day": "Mon",
+                    "time": "8:30 PM",
+                    "homeTeam": "Dallas Cowboys",
+                    "awayTeam": "Detroit Lions"
+                }
+            ]
+        },
+        {
+            "type": "season",
+            "number": "17",
+            "games": [
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Atlanta Falcons",
+                    "awayTeam": "New Orleans Saints"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Cincinnati Bengals",
+                    "awayTeam": "Baltimore Ravens"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Indianapolis Colts",
+                    "awayTeam": "Jacksonville Jaguars"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Detroit Lions",
+                    "awayTeam": "Green Bay Packers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Miami Dolphins",
+                    "awayTeam": "New England Patriots"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Minnesota Vikings",
+                    "awayTeam": "Chicago Bears"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "New York Jets",
+                    "awayTeam": "Buffalo Bills"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tennessee Titans",
+                    "awayTeam": "Houston Texans"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Philadelphia Eagles",
+                    "awayTeam": "Dallas Cowboys"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Pittsburgh Steelers",
+                    "awayTeam": "Cleveland Browns"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Tampa Bay Buccaneers",
+                    "awayTeam": "Carolina Panthers"
+                },
+                {
+                    "day": "Sun",
+                    "time": "1:00 PM",
+                    "homeTeam": "Washington Redskins",
+                    "awayTeam": "New York Giants"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Denver Broncos",
+                    "awayTeam": "Oakland Raiders"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "Los Angeles Rams",
+                    "awayTeam": "Arizona Cardinals"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "San Diego Chargers",
+                    "awayTeam": "Kansas City Chiefs"
+                },
+                {
+                    "day": "Sun",
+                    "time": "4:25 PM",
+                    "homeTeam": "San Francisco 49ers",
+                    "awayTeam": "Seattle Seahawks"
+                }
+            ]
+        }
+    ]
+}

--- a/retroSchedules/transferScheduleFromJson.js
+++ b/retroSchedules/transferScheduleFromJson.js
@@ -254,7 +254,7 @@ async function processGame(game, seasonGameTable, weekStartOccurrences,numGamesH
 
 async function convertSchedule(sourceScheduleJson, seasonGameTable, TOTAL_GAMES, targetFranchise) {
 
-  console.log("Now working on inserting the schedule from your selected year over to your target Madden 24 Franchise file...");
+  console.log("Now working on inserting this schedule into your target Madden 24 Franchise file...");
 
   // Separate the assignment from the promise
   const [

--- a/scheduleExtractorM24/scheduleExtractorM24.js
+++ b/scheduleExtractorM24/scheduleExtractorM24.js
@@ -7,7 +7,7 @@ const { tables } = require('../lookupFunctions/FranchiseTableId');
 const teamLookup = JSON.parse(fs.readFileSync('teamLookup.json', 'utf8'));
 
 // Print tool header message
-console.log("This program will allow you to extract the schedule in your Madden 24 franchise file to JSON. This tool must be run during the first week of preseason.\n")
+console.log("This program will allow you to extract the schedule in your Madden 24 franchise file to JSON. This tool must be run during the preseason.\n")
 
 // Set up franchise file
 const gameYear = FranchiseUtils.YEARS.M24;


### PR DESCRIPTION
Schedule Transfer Tool:
- Updated the 2012-16 schedule JSONs to have fixed kickoff times
- Updated the status message for the transfer process to be more generalized

Schedule Extractor:
- Updated the tool header message to reflect the new allowed weeks

Assign Vanity Gear:
- Instead of just skipping a player if they don't have a CharacterVisuals ref, it first attempts to regenerate their visuals and only skips if that somehow fails.