### PR TITLE
ISON Functions - Added fallback for out of range byte values

### DIFF
--- a/isonParser/isonFunctions.js
+++ b/isonParser/isonFunctions.js
@@ -104,6 +104,11 @@ function writeBytes(buffer, offset, data) {
 
 // Helper to write a single byte
 function writeByte(buffer, offset, byte) {
+	if(byte < 0 || byte > 255)
+	{
+		byte = 0;
+	}
+	
 	buffer.writeUInt8(byte, offset);
 	return offset + 1;
 }


### PR DESCRIPTION
Added a fallback to the write byte function so that if a value is outside the range of values for a byte, it gets written as 0 instead. Should fix some issues with bad values.