### PR TITLE
Added tool to fix duplicate roster players

### DIFF
--- a/MicroUtilities/fixDuplicateRosterPlayers/buildExe.bat
+++ b/MicroUtilities/fixDuplicateRosterPlayers/buildExe.bat
@@ -1,0 +1,1 @@
+nexe --build -i fixDuplicateRosterPlayers.js -t x64-14.15.3 -r "../../node_modules/madden-franchise/data/schemas" -r "../../Utils/FranchiseUtils.js" -r "../../node_modules/madden-franchise/services/lookupFiles/*.json" -o "fixDuplicateRosterPlayers.exe" --verbose 

--- a/MicroUtilities/fixDuplicateRosterPlayers/fixDuplicateRosterPlayers.js
+++ b/MicroUtilities/fixDuplicateRosterPlayers/fixDuplicateRosterPlayers.js
@@ -1,0 +1,65 @@
+// Required modules
+const FranchiseUtils = require('../../Utils/FranchiseUtils');
+
+// Print tool header message
+console.log("This program will fix team rosters containing duplicate player references in a Madden 25 franchise file.\n");
+
+// Set up franchise file
+const validGames = [
+	FranchiseUtils.YEARS.M25
+];
+const franchise = FranchiseUtils.init(validGames);
+const tables = FranchiseUtils.getTablesObject(franchise);
+
+franchise.on('ready', async function () {
+    // Get required tables	
+	const rosterTable = franchise.getTableByUniqueId(tables.rosterTable);
+
+	const tablesList = [rosterTable];
+
+	await FranchiseUtils.readTableRecords(tablesList);
+
+	const recordCount = rosterTable.header.recordCapacity;
+
+	// Iterate through each record in the roster table
+	for(let i = 0; i < recordCount; i++)
+	{
+		let foundRows = [];
+
+		const currRecord = rosterTable.records[i];
+
+		if(currRecord.isEmpty)
+		{
+			continue;
+		}
+
+		const numElements = currRecord.arraySize;
+
+		// Iterate through each element in the current record
+		for(let j = 0; j < numElements; j++)
+		{
+			const currElement = currRecord[`Player${j}`];
+
+			const currPlayerRow = FranchiseUtils.bin2Dec(currElement.slice(15));
+
+			if(!foundRows.includes(currPlayerRow))
+			{
+				foundRows.push(currPlayerRow);
+				continue;
+			}
+
+			// Duplicate player found, so clear the current element by taking the last player in the roster and moving them to the current element, then clear the last player
+			const lastElement = currRecord[`Player${numElements - 1}`];
+			currRecord[`Player${j}`] = lastElement;
+			currRecord[`Player${numElements - 1}`] = FranchiseUtils.ZERO_REF;
+		}
+	}
+	
+	
+	// Program complete, so print success message, save the franchise file, and exit
+	console.log("\nAll duplicate players successfully cleared.\n");
+    await FranchiseUtils.saveFranchiseFile(franchise);
+	FranchiseUtils.EXIT_PROGRAM();
+  
+});
+  


### PR DESCRIPTION
- Added a simple tool that iterates through the roster array table and resolves any instances of duplicate player references in a team's roster. Still need to investigate what is causing this condition but this should take care of the symptoms for now.