### PR TITLE
Updated madden-franchise and updated DC equipment tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "cheerio": "^1.0.0-rc.12",
         "lodash": "^4.17.21",
         "lz4": "^0.6.5",
-        "madden-franchise": "^3.5.1",
+        "madden-franchise": "^3.6.0",
         "papaparse": "^5.4.1",
         "prompt-sync": "^4.2.0",
         "puppeteer": "^15.5.0",
@@ -1090,9 +1090,9 @@
       }
     },
     "node_modules/madden-franchise": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/madden-franchise/-/madden-franchise-3.5.1.tgz",
-      "integrity": "sha512-NaC51smzpwRjmdV0NZTb0NBUDDh8xQUeUeILRwUC4oh+nqslyjoqwFzYwwm5nSttrJMEngmFANtLaNxtZPW3og==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/madden-franchise/-/madden-franchise-3.6.0.tgz",
+      "integrity": "sha512-smiQrpBZ+O3892oPxUBrrP0K/5Zl/MRfaFTLb8Kb0h7FyQKyArVjoLGBW09mr4OtSsfgOcyFxEInepP2IreeYg==",
       "license": "MIT",
       "dependencies": {
         "bit-buffer": "^0.2.5",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cheerio": "^1.0.0-rc.12",
     "lodash": "^4.17.21",
     "lz4": "^0.6.5",
-    "madden-franchise": "^3.5.1",
+    "madden-franchise": "^3.6.0",
     "papaparse": "^5.4.1",
     "prompt-sync": "^4.2.0",
     "puppeteer": "^15.5.0",

--- a/randomizeDraftClassEquipment/randomizeDraftClassEquipment.js
+++ b/randomizeDraftClassEquipment/randomizeDraftClassEquipment.js
@@ -18,7 +18,7 @@ const gameYear = franchise.schema.meta.gameYear;
 const tables = FranchiseUtils.getTablesObject(franchise);
 
 // No equipment columns in M25+, so we must use the JSON strategy
-let useJsonStrategy = gameYear >= FranchiseUtils.YEARS.M25;
+let useJsonStrategy = gameYear >= FranchiseUtils.YEARS.M24; // Latest version of madden-franchise fully supports JSON for M24, so we can now use the JSON strategy for M24 as well
 
 const lookupFileName = `all_asset_names_m${gameYear}.json`;
 
@@ -191,10 +191,7 @@ function filterByPosition(playerList, position, playerTable)
  * @param {Array<number>} miscRows A list to store row numbers of all other active players
  */
 async function enumeratePlayers(playerTable, draftRows, nflRows, miscRows)
-{
-	// Types of players that are not relevant for our purposes and can be skipped
-	const invalidStatuses = ['Retired','Deleted','None','Created'];
-	
+{	
 	// Number of rows in the player table
     const numRows = playerTable.header.recordCapacity; 
 	
@@ -339,8 +336,8 @@ franchise.on('ready', async function () {
 		}
 	}
 
-	// Regenerate visuals if we are using the player table strategy and not the JSON strategy
-	if(!useJsonStrategy)
+	// Regenerate visuals if we are using the player table strategy in M24+ and not the JSON strategy
+	if(!useJsonStrategy && gameYear >= FranchiseUtils.YEARS.M24)
 	{
 		console.log("\nRegenerating CharacterVisuals for draft class players...");
 


### PR DESCRIPTION
Updated madden-franchise to latest version.

Draft Class Equipment Randomizer:
- With the latest version of madden-franchise containing support for M24 table3 fields that have been edited in-game, shifted the logic for the equipment randomizer to use the JSON strategy for M24 as well since we can now do that.